### PR TITLE
Openapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start:crawler": "node dist/server/startCrawler.js",
     "test": " LOG_LEVEL=error node ./node_modules/mocha/bin/mocha --ui bdd ./dist/**/test/database/**/*.js ./dist/**/test/*.js",
     "migrate": "node dist/server/misc/migrate.js",
-    "commit": "npx git-cz"
+    "commit": "npx git-cz",
+    "generate:api": "node dist/server/misc/openapi/generate.js"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "emoji-strip": "latest",
     "express": "^4.17.1",
     "feedparser-promised": "^2.0.1",
+    "handlebars": "^4.7.6",
     "helmet": "^3.23.3",
     "htmlparser2": "^4.1.0",
     "http-errors": "^1.8.0",

--- a/src/server/bin/api.ts
+++ b/src/server/bin/api.ts
@@ -42,7 +42,6 @@ function userRouter(): Router {
 
     router.post("/logout", UserApi.logout);
     router.get("/lists", UserApi.getLists);
-    router.get("/invalidated", UserApi.getInvalidated);
     router.post("/bookmarked", UserApi.addBookmarked);
     router.get("/associated", UserApi.getAssociatedEpisode);
     router.get("/searchtoc", UserApi.searchToc);

--- a/src/server/bin/database/contexts/episodeContext.ts
+++ b/src/server/bin/database/contexts/episodeContext.ts
@@ -17,7 +17,9 @@ import {
     MultiSingleValue,
     Optional,
     Nullable,
-    UpdateMedium
+    UpdateMedium,
+    TypedQuery,
+    PureEpisode
 } from "../../types";
 import {
     checkIndices,
@@ -34,11 +36,11 @@ import {
 import logger from "../../logger";
 import { MysqlServerError } from "../mysqlError";
 import { escapeLike } from "../storages/storageTools";
-import { Query, OkPacket } from "mysql";
+import { OkPacket } from "mysql";
 import { storeModifications } from "../sqlTools";
 
 export class EpisodeContext extends SubContext {
-    public async getAll(uuid: Uuid): Promise<Query> {
+    public async getAll(uuid: Uuid): Promise<TypedQuery<PureEpisode>> {
         return this.queryStream(
             "SELECT episode.id, episode.partialIndex, episode.totalIndex, episode.combiIndex, " +
             "episode.part_id as partId, coalesce(progress, 0) as progress, read_date as readDate " +
@@ -48,9 +50,9 @@ export class EpisodeContext extends SubContext {
         );
     }
 
-    public async getAllReleases(): Promise<Query> {
+    public async getAllReleases(): Promise<TypedQuery<EpisodeRelease>> {
         return this.queryStream(
-            "SELECT episode_id as episodeId, source_type as sourceType, releaseDate, locked, url, title FROM episode_release"
+            "SELECT episode_id as episodeId, source_type as sourceType, toc_id as tocId, releaseDate, locked, url, title FROM episode_release"
         );
     }
 

--- a/src/server/bin/database/contexts/externalUserContext.ts
+++ b/src/server/bin/database/contexts/externalUserContext.ts
@@ -1,13 +1,12 @@
 import { SubContext } from "./subContext";
-import { ExternalUser, Uuid, MultiSingleValue, PromiseMultiSingle } from "../../types";
+import { ExternalUser, Uuid, MultiSingleValue, PromiseMultiSingle, DisplayExternalUser, TypedQuery } from "../../types";
 import { Errors, promiseMultiSingle } from "../../tools";
 import { v1 as uuidGenerator } from "uuid";
-import { Query } from "mysql";
 import { storeModifications } from "../sqlTools";
 import { ExternalStorageUser } from "../../externals/types";
 
 export class ExternalUserContext extends SubContext {
-    public async getAll(uuid: Uuid): Promise<Query> {
+    public async getAll(uuid: Uuid): Promise<TypedQuery<DisplayExternalUser>> {
         const lists = await this.parentContext.externalListContext.getAll(uuid);
         return this
             .queryStream(

--- a/src/server/bin/database/contexts/internalListContext.ts
+++ b/src/server/bin/database/contexts/internalListContext.ts
@@ -1,5 +1,5 @@
 import { SubContext } from "./subContext";
-import { List, Medium, Uuid, MultiSingleNumber, MinList, StorageList } from "../../types";
+import { List, Medium, Uuid, MultiSingleNumber, MinList, StorageList, ListMedia } from "../../types";
 import { Errors, promiseMultiSingle, multiSingle } from "../../tools";
 import { storeModifications } from "../sqlTools";
 
@@ -30,9 +30,7 @@ export class InternalListContext extends SubContext {
      * Returns all mediums of a list with
      * the list_id.
      */
-    public async getList<T extends MultiSingleNumber>(listId: T, media: number[], uuid: Uuid):
-        Promise<{ list: List[] | List; media: Medium[] }> {
-
+    public async getList<T extends MultiSingleNumber>(listId: T, media: number[], uuid: Uuid): Promise<ListMedia> {
         const toLoadMedia: Set<number> = new Set();
         // TODO: 29.06.2019 replace with id IN (...)
         const lists = await promiseMultiSingle(listId, async (id: number) => {

--- a/src/server/bin/database/contexts/mediumContext.ts
+++ b/src/server/bin/database/contexts/mediumContext.ts
@@ -15,11 +15,12 @@ import {
     PromiseMultiSingle,
     MultiSingleValue,
     MultiSingleNumber,
-    MediumToc
+    MediumToc,
+    TypedQuery
 } from "../../types";
 import { count, Errors, getElseSet, invalidId, multiSingle, promiseMultiSingle } from "../../tools";
 import { escapeLike } from "../storages/storageTools";
-import { Query, OkPacket } from "mysql";
+import { OkPacket } from "mysql";
 import { storeModifications } from "../sqlTools";
 
 export class MediumContext extends SubContext {
@@ -215,7 +216,7 @@ export class MediumContext extends SubContext {
         });
     }
 
-    public async getAllMediaFull(): Promise<Query> {
+    public async getAllMediaFull(): Promise<TypedQuery<SimpleMedium>> {
         return this.queryStream(
             "SELECT " +
             "id, countryOfOrigin, languageOfOrigin, author, title," +

--- a/src/server/bin/database/contexts/mediumInWaitContext.ts
+++ b/src/server/bin/database/contexts/mediumInWaitContext.ts
@@ -1,6 +1,5 @@
 import { SubContext } from "./subContext";
-import { MediumInWait } from "../databaseTypes";
-import { Medium, SimpleMedium, MultiSingleValue, EmptyPromise } from "../../types";
+import { Medium, SimpleMedium, MultiSingleValue, EmptyPromise, MediumInWait } from "../../types";
 import { equalsIgnore, ignore, promiseMultiSingle, sanitizeString, multiSingle } from "../../tools";
 import { storeModifications } from "../sqlTools";
 

--- a/src/server/bin/database/contexts/partContext.ts
+++ b/src/server/bin/database/contexts/partContext.ts
@@ -1,7 +1,6 @@
 import { SubContext } from "./subContext";
-import { Episode, FullPart, MinPart, Part, ShallowPart, SimpleEpisode, Uuid, MultiSingleNumber, Optional, VoidablePromise, SimpleRelease } from "../../types";
+import { Episode, FullPart, MinPart, Part, ShallowPart, SimpleEpisode, Uuid, MultiSingleNumber, Optional, VoidablePromise, SimpleRelease, TypedQuery } from "../../types";
 import { combiIndex, getElseSetObj, multiSingle, separateIndex } from "../../tools";
-import { Query } from "mysql";
 import { MysqlServerError } from "../mysqlError";
 import { storeModifications } from "../sqlTools";
 
@@ -11,7 +10,7 @@ interface MinEpisode {
 }
 
 export class PartContext extends SubContext {
-    public async getAll(): Promise<Query> {
+    public async getAll(): Promise<TypedQuery<MinPart>> {
         return this.queryStream(
             "SELECT id, totalIndex, partialIndex, title, medium_id as mediumId FROM part"
         );

--- a/src/server/bin/database/contexts/queryContext.ts
+++ b/src/server/bin/database/contexts/queryContext.ts
@@ -11,7 +11,9 @@ import {
     PromiseMultiSingle,
     Optional,
     PageInfo,
-    Primitive
+    Primitive,
+    DataStats,
+    NewData,
 } from "../../types";
 import { Errors, getElseSet, getElseSetObj, ignore, multiSingle, promiseMultiSingle, batch } from "../../tools";
 import logger from "../../logger";
@@ -556,7 +558,7 @@ export class QueryContext implements ConnectionContext {
         return this.con.queryStream(query, parameter);
     }
 
-    public async getNew(uuid: Uuid, date = new Date(0)): Promise<any> {
+    public async getNew(uuid: Uuid, date = new Date(0)): Promise<NewData> {
         const episodeReleasePromise = this.query(
             "SELECT episode_id as episodeId, title, url, releaseDate, locked " +
             "FROM episode_release WHERE updated_at > ?",
@@ -629,7 +631,7 @@ export class QueryContext implements ConnectionContext {
         };
     }
 
-    public async getStat(uuid: Uuid): Promise<any> {
+    public async getStat(uuid: Uuid): Promise<DataStats> {
         const episodePromise = this.query(
             "SELECT part_id, count(distinct episode.id) as episodeCount, sum(distinct episode.id) as episodeSum, count(url) as releaseCount " +
             "FROM episode LEFT JOIN episode_release ON episode.id=episode_release.episode_id " +
@@ -671,12 +673,12 @@ export class QueryContext implements ConnectionContext {
         const extUser = {};
 
         for (const toc of tocs) {
-            const mediumParts = getElseSetObj(mediaStats, toc.medium_id, () => {
+            const medium = getElseSetObj(mediaStats, toc.medium_id, () => {
                 return {
                     tocs: 0
                 };
             });
-            mediumParts.tocs = toc.count;
+            medium.tocs = toc.count;
         }
 
         for (const part of parts) {

--- a/src/server/bin/database/databaseTypes.ts
+++ b/src/server/bin/database/databaseTypes.ts
@@ -57,12 +57,6 @@ export enum InvalidationType {
     ANY = INSERT | UPDATE | DELETE
 }
 
-export interface MediumInWait {
-    title: string;
-    medium: MediaType;
-    link: string;
-}
-
 export interface ConnectionContext {
     startTransaction(): EmptyPromise;
 

--- a/src/server/bin/database/storages/storage.ts
+++ b/src/server/bin/database/storages/storage.ts
@@ -1,6 +1,6 @@
 import mySql from "promise-mysql";
 import env from "../../env";
-import { Invalidation, MetaResult, Result, Uuid, PropertyNames, StringKeys, PromiseFunctions, EmptyPromise, MultiSingleValue, Nullable } from "../../types";
+import { Invalidation, MetaResult, Result, Uuid, PropertyNames, StringKeys, PromiseFunctions, EmptyPromise, MultiSingleValue, Nullable, DataStats, NewData } from "../../types";
 import logger from "../../logger";
 import { databaseSchema } from "../databaseSchema";
 import { delay, isQuery, isString } from "../../tools";
@@ -288,11 +288,11 @@ export class Storage {
         return inContext((context) => context.queueNewTocs());
     }
 
-    public getStats(uuid: Uuid): Promise<any> {
+    public getStats(uuid: Uuid): Promise<DataStats> {
         return inContext((context) => context.getStat(uuid));
     }
 
-    public getNew(uuid: Uuid, date?: Date): Promise<any> {
+    public getNew(uuid: Uuid, date?: Date): Promise<NewData> {
         return inContext((context) => context.getNew(uuid, date));
     }
 

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -203,7 +203,7 @@ export function generateExpressApiObject(fileNames: string[], options: ts.Compil
     }
     const result: ExportExpressResult = parser.getExpressResult();
 
-    // console.log(JSON.stringify(result, null, 4));
+    // log(JSON.stringify(result, null, 4));
     // print out the doc
     // fs.writeFileSync("classes.json", JSON.stringify(output, undefined, 4));
     return transformToOpenApi(result);
@@ -233,7 +233,7 @@ class TypeInferrer {
             const symbol = this.getSymbol(node);
 
             if (!symbol) {
-                console.log("No Symbol for Identifier: " + node);
+                log("No Symbol for Identifier: " + node);
             } else {
                 const type = this.checker.getTypeOfSymbolAtLocation(symbol, node);
 
@@ -249,15 +249,15 @@ class TypeInferrer {
             const identifier = getFirstCallIdentifier(node);
 
             if (!identifier) {
-                console.log("No Identifier for CallExpression: " + node.getText());
+                log("No Identifier for CallExpression: " + node.getText());
             } else {
                 const callSymbol = this.getSymbol(identifier);
                 if (!callSymbol) {
-                    console.log("No Symbol for Identifier of CallExpression: " + node.getText());
+                    log("No Symbol for Identifier of CallExpression: " + node.getText());
                 } else {
                     const signature = this.checker.getSignatureFromDeclaration(callSymbol.valueDeclaration as FunctionDeclaration);
                     if (!signature) {
-                        console.log("No Signature for CallExpression: " + node.getText());
+                        log("No Signature for CallExpression: " + node.getText());
                     } else {
                         const type = this.checker.getReturnTypeOfSignature(signature);
                     }
@@ -359,7 +359,7 @@ class TypeInferrer {
         const symbol = type.getSymbol();
 
         if (!symbol) {
-            console.log("No Symbol for Type: " + type);
+            log("No Symbol for Type: " + type);
             return null;
         }
         if (ts.isFunctionLike(symbol.valueDeclaration)) {
@@ -378,7 +378,7 @@ class TypeInferrer {
                     elementType,
                 } as ArrayType;
             } else {
-                console.log("Array type does not have exactly one TypeParameter: " + arrayTypes);
+                log("Array type does not have exactly one TypeParameter: " + arrayTypes);
                 return null;
             }
         }
@@ -468,7 +468,7 @@ class Parser {
             const returnedRouter = functionEntry.returnRouter;
 
             if (!returnedRouter) {
-                console.log("Exported Function does not return a router: " + name);
+                log("Exported Function does not return a router: " + name);
                 continue;
             }
             const routerEntry = this.routerMap.get(returnedRouter);
@@ -489,7 +489,7 @@ class Parser {
             const subRouterSymbol = functionCallEntry.returnRouter;
 
             if (!subRouterSymbol) {
-                console.log("Middleware Function does not return router");
+                log("Middleware Function does not return router");
                 continue;
             }
             if (subRouterSymbol === this.currentlyConvertingRouter) {
@@ -584,7 +584,7 @@ class Parser {
         const currentFunctionSymbol = container.currentStackElement.symbol;
         // prevent infinite recursion
         if (container.callStack.find((value) => value.symbol === currentFunctionSymbol)) {
-            console.log("Recursive call of: " + middlewareSignature.getText());
+            log("Recursive call of: " + middlewareSignature.getText());
             return;
         }
         container.callStack.push(container.currentStackElement);
@@ -602,7 +602,7 @@ class Parser {
         });
 
         if (!requestParamSymbol && !responseParamSymbol) {
-            console.log(
+            log(
                 "Faulty Function: Missing either Request and Response Parameter: " + container.middleware.getText()
             );
             return;
@@ -655,7 +655,7 @@ class Parser {
                         container.requestInfo.queryParams[queryProperty] = {};
                     }
                 } else {
-                    console.log("unknown request.query property: " + requestAccess.getText());
+                    log("unknown request.query property: " + requestAccess.getText());
                 }
             } else if (propertyIdentifier.text === "body") {
                 const queryProperties = this.getPropertyAccess(requestAccess, container);
@@ -666,7 +666,7 @@ class Parser {
                         container.requestInfo.queryParams[queryProperty] = {};
                     }
                 } else {
-                    console.log("unknown request.body property: " + requestAccess.getText());
+                    log("unknown request.body property: " + requestAccess.getText());
                 }
             }
         }
@@ -685,7 +685,7 @@ class Parser {
             const identifier = getFirstCallIdentifier(callExpression);
 
             if (!identifier) {
-                console.log("No Identifier for Response.method: " + callExpression.getText());
+                log("No Identifier for Response.method: " + callExpression.getText());
                 continue;
             }
             this.processResponseCall(callExpression, identifier.text, container);
@@ -707,12 +707,12 @@ class Parser {
             if (ts.isIdentifierOrPrivateIdentifier(callExpression.expression)) {
                 const callSymbol = this.checker.getSymbolAtLocation(callExpression.expression);
                 if (!callSymbol) {
-                    console.log("No Symbol for Call: " + callExpression.expression.getText());
+                    log("No Symbol for Call: " + callExpression.expression.getText());
                     continue;
                 }
                 const declaration = callSymbol.valueDeclaration;
                 if (!ts.isFunctionLike(declaration)) {
-                    console.log(
+                    log(
                         "Value Declaration of Call Symbol is no SignatureDeclaration: "
                         + callExpression.expression.getText()
                     );
@@ -748,7 +748,7 @@ class Parser {
             const headerValue = callExpression.arguments[1];
 
             if (!headerKey || !ts.isStringLiteralLike(headerKey)) {
-                console.log("expected string literal as header key: " + callExpression.getText());
+                log("expected string literal as header key: " + callExpression.getText());
                 return;
             }
             let value = null;
@@ -756,7 +756,7 @@ class Parser {
             // TODO: 10.08.2020 accept string array also
             if (headerValue) {
                 if (!ts.isStringLiteralLike(headerValue)) {
-                    console.log("expected string literal as header key: " + callExpression.getText());
+                    log("expected string literal as header key: " + callExpression.getText());
                     return;
                 } else {
                     value = headerValue.text;
@@ -843,7 +843,7 @@ class Parser {
             const type = callExpression.arguments[0];
         } else {
             // or a call of a super type of express.Response like http.ServerResponse or http.OutgoingMessage
-            console.log("Unknown call on response: " + callExpression.getText());
+            log("Unknown call on response: " + callExpression.getText());
         }
     }
 
@@ -879,7 +879,7 @@ class Parser {
             const keySymbol = this.getSymbol(node);
 
             if (!keySymbol) {
-                console.log("cannot find symbol for ElementAccess of: " + node.parent.getText());
+                log("cannot find symbol for ElementAccess of: " + node.parent.getText());
                 return null;
             }
             if (ts.isParameter(keySymbol.valueDeclaration)) {
@@ -891,11 +891,11 @@ class Parser {
                 }
                 return this.getStringLiteralValue(argument, container, stackLevel - 1);
             } else {
-                console.log("Unknown node type, not a parameter: " + keySymbol.valueDeclaration.getText());
+                log("Unknown node type, not a parameter: " + keySymbol.valueDeclaration.getText());
             }
             // TODO: 10.08.2020 try to infer from variableDeclaration
         } else {
-            console.log("unknown node: neither StringLiteral or Identifier: " + node.getText());
+            log("unknown node: neither StringLiteral or Identifier: " + node.getText());
         }
         return null;
     }
@@ -917,13 +917,13 @@ class Parser {
                         || identifierSymbol === variableSymbol);
             });
         if (returnNodes.length > 1) {
-            console.log("more than one return router statement");
+            log("more than one return router statement");
         } else if (returnNodes.length === 1) {
             const lastReturn = returnNodes.pop() as ts.Node;
             const routerIdentifier = getFirst(lastReturn, SyntaxKind.Identifier) as ts.Node;
             return this.checker.getSymbolAtLocation(routerIdentifier) as ts.Symbol;
         } else {
-            console.log("No Router returned for function: " + outerFunction.getText());
+            log("No Router returned for function: " + outerFunction.getText());
         }
     }
 
@@ -946,7 +946,7 @@ class Parser {
                     const outerFunctionSymbol = this.checker.getSymbolAtLocation(outerFunction.name as Identifier);
 
                     if (!outerFunctionSymbol) {
-                        console.log("Missing Symbol for outer Function: " + outerFunction.getText());
+                        log("Missing Symbol for outer Function: " + outerFunction.getText());
                         return;
                     }
                     const functionEntry = this.getFunctionEntry(outerFunctionSymbol);
@@ -960,12 +960,12 @@ class Parser {
                     const routerSymbol = this.checker.getSymbolAtLocation(routerIdentifier);
 
                     if (!routerSymbol) {
-                        console.log("No Symbol for Router Variable at position: " + routerIdentifier.pos);
+                        log("No Symbol for Router Variable at position: " + routerIdentifier.pos);
                         return;
                     }
                     const call = getFirst(initializer, SyntaxKind.CallExpression) as CallExpression;
                     if (call.arguments.length !== 1) {
-                        console.log("Require exactly on argument for method 'route' on position: " + call.pos);
+                        log("Require exactly on argument for method 'route' on position: " + call.pos);
                         return;
                     } else {
                         const expression = call.arguments[0];
@@ -976,14 +976,14 @@ class Parser {
                             const routePath = expression.text;
                             routerEntry.routes[routePath] = this.getRouteEntry(variableSymbol);
                         } else {
-                            console.log("Require string literal as path for method 'route' on position: " + call.pos);
+                            log("Require string literal as path for method 'route' on position: " + call.pos);
                         }
                     }
                 } else {
-                    console.log(`Unknown Call Symbol for ${symbol.getName()}`);
+                    log(`Unknown Call Symbol for ${symbol.getName()}`);
                 }
             } else {
-                console.log(`No Symbol for ${node.getText()}`);
+                log(`No Symbol for ${node.getText()}`);
             }
         }
     }
@@ -994,7 +994,7 @@ class Parser {
         const parameterList = getFirst(node, ts.SyntaxKind.SyntaxList) as SyntaxList;
         if (isHttpMethod(name)) {
             if (!parameterList) {
-                console.log("No Parameter for Http method call!");
+                log("No Parameter for Http method call!");
                 return;
             }
             const pathLiteral = parameterList.getChildAt(0) as StringLiteral;
@@ -1008,7 +1008,7 @@ class Parser {
             });
         } else if (name.toLowerCase() === "use") {
             if (!parameterList) {
-                console.log(`No Middleware supplied to ${variableIdentifier.getText()}.use!`);
+                log(`No Middleware supplied to ${variableIdentifier.getText()}.use!`);
                 return;
             }
             if (parameterList.getChildCount() === 1) {
@@ -1023,6 +1023,7 @@ class Parser {
                     const nextCall = getFirst(middleWareNode, ts.SyntaxKind.CallExpression);
 
                     const routerEntry: RouterEntry = this.getRouterEntry(variableSymbol);
+                    // type of *.use("my-path", functionReturninARouter())
                     if (nextCall && ts.isCallExpression(nextCall)) {
                         const callIdentifier = getFirstCallIdentifier(nextCall);
 
@@ -1034,22 +1035,22 @@ class Parser {
                                 const subRouter = routerEntry.subRouter;
                                 subRouter[text] = functionEntry;
                             } else {
-                                console.log("No Function symbol for: " + callIdentifier.getText());
+                                log("No Function symbol for: " + callIdentifier.getText());
                             }
                         } else {
-                            console.log("No Call Identifier for Call Expression: " + nextCall.getText());
+                            log("No Call Identifier for Call Expression: " + nextCall.getText());
                         }
                     } else {
-                        console.log("Router.use where second argument is not a router:" + node.getText());
+                        log("Router.use where second argument is not a router:" + node.getText());
                     }
                 } else {
-                    console.log("Expected a string literal as path: " + node.getText());
+                    log("Expected a string literal as path: " + node.getText());
                 }
             } else {
-                console.log(`Not exactly one or two Arguments supplied to *.use!: ${propertyName.parent.getText()}`);
+                log(`Not exactly one or two Arguments supplied to *.use!: ${propertyName.parent.getText()}`);
             }
         } else {
-            console.log(`Non http Method call: ${name}() on ${variableIdentifier.getText()}`);
+            log(`Non http Method call: ${name}() on ${variableIdentifier.getText()}`);
         }
     }
 
@@ -1059,7 +1060,7 @@ class Parser {
         const parameterList = getFirst(node, ts.SyntaxKind.SyntaxList) as SyntaxList;
         if (isHttpMethod(name)) {
             if (!parameterList) {
-                console.log("No Parameter for Http method call!");
+                log("No Parameter for Http method call!");
                 return;
             }
             const middleWareNode = parameterList.getChildAt(0);
@@ -1067,7 +1068,7 @@ class Parser {
             const routeEntry = this.getRouteEntry(variableSymbol);
             routeEntry[name] = middleWareNode;
         } else {
-            console.log(`Non http Method call: ${name}() on ${variableIdentifier.getText()}`);
+            log(`Non http Method call: ${name}() on ${variableIdentifier.getText()}`);
         }
     }
 
@@ -1084,7 +1085,7 @@ class Parser {
             const variableSymbol = this.checker.getSymbolAtLocation(variableIdentifier);
 
             if (!variableSymbol) {
-                console.log("Variable Property Access has no Symbol: " + node.getText());
+                log("Variable Property Access has no Symbol: " + node.getText());
                 return;
             }
             if (this.routerVariables.has(variableSymbol)) {
@@ -1092,7 +1093,7 @@ class Parser {
             } else if (this.routeMap.has(variableSymbol)) {
                 this.processRoute(propertyName, node, variableSymbol, variableIdentifier);
             } else {
-                console.log("Unknown Method Call: " + node.getText());
+                log("Unknown Method Call: " + node.getText());
             }
         } else {
             const firstIdentifier = getFirst(node, ts.SyntaxKind.Identifier);
@@ -1100,9 +1101,9 @@ class Parser {
                 const symbol = this.checker.getSymbolAtLocation(firstIdentifier);
 
                 if (symbol) {
-                    console.log(`${ts.SyntaxKind[node.kind]}: Call ${node.getFullText()}`);
+                    log(`${ts.SyntaxKind[node.kind]}: Call ${node.getFullText()}`);
                 } else {
-                    console.log(`No Symbol for ${firstIdentifier.getText()}`);
+                    log(`No Symbol for ${firstIdentifier.getText()}`);
                 }
             }
         }
@@ -1457,7 +1458,7 @@ function routerResultToOpenApi(router: RouterResult, paths: PathsObject, absolut
         const pathObject: PathItemObject = paths[currentPath] = {};
 
         for (const [method, middleware] of Object.entries(routeValue)) {
-            console.log(`${currentPath}: ${method}`);
+            log(`${currentPath}: ${method}`);
             const routeRequestObject: RequestBodyObject = {
                 content: JSON.parse(contentCopyString)
             };
@@ -1514,4 +1515,8 @@ function routerResultToOpenApi(router: RouterResult, paths: PathsObject, absolut
         const subPath = (absolutePath + pathKey).replace("//", "/");
         routerResultToOpenApi(subRouter, paths, subPath);
     }
+}
+
+function log(...any: any[]): void {
+    console.log(...any);
 }

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -1033,8 +1033,10 @@ class Parser {
             }
             if (ts.isFunctionLike(initializer)) {
                 stackElement = this.createStackElement(initializer, valueDeclaration.name);
-            } else {
+            } else if (ts.isIdentifierOrPrivateIdentifier(initializer)) {
                 // TODO: 10.08.2020 middleware aliases like putProgress
+                return this.middlewareToResult(initializer);
+            } else {
                 return middlewareResult;
             }
         } else if (ts.isFunctionDeclaration(valueDeclaration)) {

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -431,21 +431,7 @@ class TypeInferrer {
 
         if (signature) {
             const returnType = this.checker.getReturnTypeOfSignature(signature);
-            const typeSymbol = returnType.getSymbol();
-
-            if (typeSymbol && typeSymbol.getName() === "Promise") {
-                // @ts-expect-error
-                const promiseTypes = this.checker.getTypeArguments(returnType);
-
-                if (promiseTypes.length === 1) {
-                    const promiseType = promiseTypes[0];
-                    return this.typeToResult(promiseType);
-                } else {
-                    log("?");
-                }
-            } else {
-                return this.typeToResult(returnType);
-            }
+            return this.typeToResult(returnType);
         } else {
             log("?");
         }

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -514,6 +514,11 @@ class TypeInferrer {
             } as StringType;
         }
 
+        // check if it is enum before checking if it is an union, because enums are "special" unions
+        if (isEnumLikeType(type)) {
+            return this.getEnumType(type, type.getSymbol() as ts.Symbol);
+        }
+
         if (type.isUnionOrIntersection()) {
             const subTypes = type.types.map(subType => this.typeToResult(subType));
             if (subTypes.some(value => !value)) {
@@ -1852,6 +1857,11 @@ function isBooleanLiteralType(value: ts.Type): value is BooleanLiteralType {
 function isStringLiteralType(value: ts.Type): value is ts.StringLiteralType {
     return !!(value.flags & ts.TypeFlags.StringLiteral);
 }
+
+function isEnumLikeType(value: ts.Type): boolean {
+    return !!(value.flags & ts.TypeFlags.EnumLike);
+}
+
 
 function nextNode(node: ts.Node): Nullable<ts.Node> {
     if (!node.parent) {

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -1963,19 +1963,19 @@ function routerResultToOpenApi(router: RouterResult, paths: PathsObject, absolut
     const contentCopyString = JSON.stringify(requestObject.content);
 
     for (const routerPath of router.paths) {
-        const pathObject: PathItemObject = {};
+        const currentPath = normalizePath(absolutePath + routerPath.path);
+        const pathObject: PathItemObject = paths[currentPath] ? paths[currentPath] : (paths[currentPath] = {});
         const pathRequestObject: RequestBodyObject = {
             content: JSON.parse(contentCopyString)
         };
         const middleware = routerPath.middleware;
         const operation = setPathObject(middleware, routerPath.method, pathRequestObject, genericParameters);
         pathObject[routerPath.method] = operation;
-        paths[normalizePath(absolutePath + routerPath.path)] = pathObject;
     }
 
     for (const [pathKey, routeValue] of Object.entries(router.routes)) {
         const currentPath = normalizePath(absolutePath + pathKey);
-        const pathObject: PathItemObject = paths[currentPath] = {};
+        const pathObject: PathItemObject = paths[currentPath] ? paths[currentPath] : (paths[currentPath] = {});
 
         for (const [method, middleware] of Object.entries(routeValue)) {
             const routeRequestObject: RequestBodyObject = {
@@ -2122,9 +2122,9 @@ function toSchema(params?: TypeResult | null): SchemaObject | undefined {
         }
     } else if (params.type === "Union") {
         const union = params as UnionType;
-        const anyOf = union.unionTypes.map(toSchema).filter(v => v) as SchemaObject[];
-        schema.anyOf = anyOf;
-        schema.title = params.type + anyOf.map(v => v.title || v.type).map(v => v.slice(0, 1).toUpperCase() + v.slice(1)).join("")
+        const oneOf = union.unionTypes.map(toSchema).filter(v => v) as SchemaObject[];
+        schema.oneOf = oneOf;
+        schema.title = params.type + oneOf.map(v => v.title || v.type).map(v => v.slice(0, 1).toUpperCase() + v.slice(1)).join("")
     } else if (params.type === "Array") {
         const array = params as ArrayType;
         schema.items = toSchema(array.elementType);

--- a/src/server/bin/misc/openapi/exportOpenApi.ts
+++ b/src/server/bin/misc/openapi/exportOpenApi.ts
@@ -228,14 +228,14 @@ class TypeInferrer {
         this.checker = checker
     }
 
-    public inferType(body: ts.Node, stackElement: StackElement): Nullable<TypeResult> {
-        if (ts.isIdentifier(body)) {
-            const symbol = this.getSymbol(body);
+    public inferType(node: ts.Node, stackElement: StackElement): Nullable<TypeResult> {
+        if (ts.isIdentifier(node)) {
+            const symbol = this.getSymbol(node);
 
             if (!symbol) {
-                console.log("No Symbol for Identifier: " + body);
+                console.log("No Symbol for Identifier: " + node);
             } else {
-                const type = this.checker.getTypeOfSymbolAtLocation(symbol, body);
+                const type = this.checker.getTypeOfSymbolAtLocation(symbol, node);
 
                 if (this.checker.typeToString(type) === "any") {
                     return this.inferAny(symbol, stackElement);
@@ -243,21 +243,21 @@ class TypeInferrer {
                     // TODO: 11.08.2020 do cool stuff with type
                 }
             }
-        } else if (ts.isLiteralExpression(body)) {
-            const contextualType = this.checker.getContextualType(body);
-        } else if (ts.isCallExpression(body)) {
-            const identifier = getFirstCallIdentifier(body);
+        } else if (ts.isLiteralExpression(node)) {
+            const contextualType = this.checker.getContextualType(node);
+        } else if (ts.isCallExpression(node)) {
+            const identifier = getFirstCallIdentifier(node);
 
             if (!identifier) {
-                console.log("No Identifier for CallExpression: " + body.getText());
+                console.log("No Identifier for CallExpression: " + node.getText());
             } else {
                 const callSymbol = this.getSymbol(identifier);
                 if (!callSymbol) {
-                    console.log("No Symbol for Identifier of CallExpression: " + body.getText());
+                    console.log("No Symbol for Identifier of CallExpression: " + node.getText());
                 } else {
                     const signature = this.checker.getSignatureFromDeclaration(callSymbol.valueDeclaration as FunctionDeclaration);
                     if (!signature) {
-                        console.log("No Signature for CallExpression: " + body.getText());
+                        console.log("No Signature for CallExpression: " + node.getText());
                     } else {
                         const type = this.checker.getReturnTypeOfSignature(signature);
                     }

--- a/src/server/bin/misc/openapi/generate.ts
+++ b/src/server/bin/misc/openapi/generate.ts
@@ -1,15 +1,129 @@
 import { generateExpressApiObject } from "./exportOpenApi";
 import ts from "typescript";
 import { generateOpenApiSpec, generateWebClient } from "./transformer";
+import { OperationObject, ParameterObject, SchemaObject, RequestBodyObject, OpenApiObject } from "./types";
+import yaml from "js-yaml";
+import fs from "fs/promises";
 
-function GenerateOpenApi(file: string) {
+async function GenerateOpenApi(file: string) {
     const openApiObject = generateExpressApiObject([file], {
         target: ts.ScriptTarget.ES5,
         module: ts.ModuleKind.CommonJS
     });
 
-    generateOpenApiSpec(openApiObject);
-    generateWebClient(openApiObject);
+    await readHook(openApiObject);
+
+    await generateOpenApiSpec(openApiObject);
+    await generateWebClient(openApiObject);
+}
+
+async function readHook(openApiObject: OpenApiObject) {
+    const hook = yaml.load(await fs.readFile("openApiTypeHook.yaml", { encoding: "utf8" }));
+    const methods = ["get", "delete", "post", "put"];
+
+    for (const [path, value] of Object.entries(openApiObject.paths)) {
+        const input: any = hook[path];
+
+        for (const method of methods) {
+            // @ts-expect-error
+            const operation: OperationObject = value[method];
+            const methodInput: any = input && input[method];
+
+            if (operation) {
+                if (operation.parameters && operation.parameters.length) {
+                    const inputParameter = methodInput.parameter || [];
+
+                    operation.parameters.forEach(p => {
+                        const param = p as ParameterObject;
+
+                        const inputParam = inputParameter[param.name];
+
+                        if (!inputParam) {
+                            return;
+                        }
+                        param.schema = inputParam;
+                    });
+                }
+
+                if (operation.requestBody) {
+                    const requestSchema = (operation.requestBody as RequestBodyObject).content["application/json"]?.schema as SchemaObject;
+
+                    if (requestSchema && requestSchema.properties) {
+                        const parameterInput: Record<string, SchemaObject> = methodInput.requestBody || {};
+
+                        for (const [key, schema] of Object.entries(requestSchema.properties)) {
+                            if (!schema || (schema as SchemaObject).type === "any" && parameterInput[key]) {
+                                requestSchema.properties[key] = parameterInput[key];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async function writeHook(openApiObject: OpenApiObject) {
+    
+    const hookOutput: any = {};
+    const methods = ["get", "delete", "post", "put"];
+
+    for (const [path, value] of Object.entries(openApiObject.paths)) {
+        const output: any = {
+
+        };
+        for (const method of methods) {
+            // @ts-expect-error
+            const operation: OperationObject = value[method];
+            const methodOutput: any = {};
+
+            if (operation) {
+                if (operation.parameters && operation.parameters.length) {
+                    const parameterOutput: Record<string, SchemaObject> = methodOutput.parameter = {};
+
+                    operation.parameters.forEach(p => {
+                        const param = p as ParameterObject;
+
+                        parameterOutput[param.name] = {
+                            ...(param.schema as SchemaObject || {
+                                type: "string"
+                            })
+                        };
+                    });
+                }
+
+                if (operation.requestBody) {
+                    const requestSchema = (operation.requestBody as RequestBodyObject).content["application/json"]?.schema as SchemaObject;
+
+                    if (requestSchema && requestSchema.properties) {
+                        const parameterOutput: Record<string, SchemaObject> = {};
+
+                        for (const [key, schema] of Object.entries(requestSchema.properties)) {
+                            if (!schema || (schema as SchemaObject).type === "any") {
+                                parameterOutput[key] = {
+                                    ...(schema as SchemaObject || {
+                                        type: "string"
+                                    }),
+                                    type: "string",
+                                };
+                            }
+                        }
+                        if (Object.keys(parameterOutput).length) {
+                            methodOutput.requestBody = parameterOutput;
+                        }
+                    }
+                }
+            }
+            if (Object.keys(methodOutput).length) {
+                output[method] = methodOutput;
+            }
+        }
+        if (Object.keys(output).length) {
+            hookOutput[path] = output;
+        }
+    }
+
+    await fs.writeFile("openApiTypeHook.yaml", yaml.dump(hookOutput), { encoding: "utf8" });
 }
 
 GenerateOpenApi("./src/server/bin/api.ts");

--- a/src/server/bin/misc/openapi/generate.ts
+++ b/src/server/bin/misc/openapi/generate.ts
@@ -1,12 +1,7 @@
 import { OpenApiObject } from "./types";
 import { generateExpressApiObject } from "./exportOpenApi";
 import ts from "typescript";
-import yaml from "js-yaml";
-import fs from "fs";
-
-function templateOpenApi(openApi: OpenApiObject): string {
-    return yaml.dump(openApi);
-}
+import { generateOpenApiSpec, generateWebClient } from "./transformer";
 
 function GenerateOpenApi(file: string) {
     const openApiObject = generateExpressApiObject([file], {
@@ -14,8 +9,8 @@ function GenerateOpenApi(file: string) {
         module: ts.ModuleKind.CommonJS
     });
 
-    const templateResult = templateOpenApi(openApiObject);
-    fs.writeFileSync("./result.yaml", templateResult, { encoding: "utf8" });
+    generateOpenApiSpec(openApiObject);
+    generateWebClient(openApiObject);
 }
 
 GenerateOpenApi("./src/server/bin/api.ts");

--- a/src/server/bin/misc/openapi/generate.ts
+++ b/src/server/bin/misc/openapi/generate.ts
@@ -1,0 +1,21 @@
+import { OpenApiObject } from "./types";
+import { generateExpressApiObject } from "./exportOpenApi";
+import ts from "typescript";
+import yaml from "js-yaml";
+import fs from "fs";
+
+function templateOpenApi(openApi: OpenApiObject): string {
+    return yaml.dump(openApi);
+}
+
+function GenerateOpenApi(file: string) {
+    const openApiObject = generateExpressApiObject([file], {
+        target: ts.ScriptTarget.ES5,
+        module: ts.ModuleKind.CommonJS
+    });
+
+    const templateResult = templateOpenApi(openApiObject);
+    fs.writeFileSync("./result.yaml", templateResult, { encoding: "utf8" });
+}
+
+GenerateOpenApi("./src/server/bin/api.ts");

--- a/src/server/bin/misc/openapi/generate.ts
+++ b/src/server/bin/misc/openapi/generate.ts
@@ -1,4 +1,3 @@
-import { OpenApiObject } from "./types";
 import { generateExpressApiObject } from "./exportOpenApi";
 import ts from "typescript";
 import { generateOpenApiSpec, generateWebClient } from "./transformer";

--- a/src/server/bin/misc/openapi/generate.ts
+++ b/src/server/bin/misc/openapi/generate.ts
@@ -1,6 +1,6 @@
 import { generateExpressApiObject } from "./exportOpenApi";
 import ts from "typescript";
-import { generateOpenApiSpec, generateWebClient } from "./transformer";
+import { generateOpenApiSpec, generateWebClient, generateValidator } from "./transformer";
 import { OperationObject, ParameterObject, SchemaObject, RequestBodyObject, OpenApiObject } from "./types";
 import yaml from "js-yaml";
 import fs from "fs/promises";
@@ -15,6 +15,7 @@ async function GenerateOpenApi(file: string) {
 
     await generateOpenApiSpec(openApiObject);
     await generateWebClient(openApiObject);
+    await generateValidator(openApiObject);
 }
 
 async function readHook(openApiObject: OpenApiObject) {

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -1,6 +1,6 @@
 import handlebars from "handlebars";
 import fs from "fs/promises";
-import { 
+import {
     OpenApiObject,
     OperationObject,
     PathItemObject,
@@ -33,18 +33,132 @@ interface TemplateContext {
     schemata: Record<string, any>;
 }
 
-export async function generateWebClient(data: OpenApiObject): Promise<void> {
-    const keyReg = /\/+/g;
-    const validKeyReg = /^[a-z_][a-zA-Z_0-9]*$/;
+export async function generateWebClient(data: Readonly<OpenApiObject>): Promise<void> {
+    return new JSWebClientGenerator(data).generate()
+}
 
-    function schemaToJSType(schema?: SchemaObject): string | handlebars.SafeString {
+abstract class TemplateGenerator {
+    protected root: Readonly<OpenApiObject>;
+    private templateSource: string;
+    private templateTarget: string;
+
+    protected constructor(data: Readonly<OpenApiObject>, templateSource: string, templateTarget: string) {
+        this.root = data;
+        this.templateSource = templateSource;
+        this.templateTarget = templateTarget;
+    }
+
+    protected resolveReference(reference: ReferenceObject): SchemaObject {
+        // check if it refers to current root
+        if (reference.$ref.startsWith("#")) {
+            if (reference.$ref.startsWith("#/components/schemas/")) {
+                if (!this.root.components?.schemas) {
+                    throw Error("Unable to Resolve Reference: " + reference.$ref + ", missing schemata");
+                }
+                const schema = this.root.components.schemas[reference.$ref.slice("#/components/schemas/".length)]
+
+                // for now do not recursively check reference
+                if (schema && !isRefObj(schema)) {
+                    return schema;
+                }
+            }
+        }
+        throw Error("Unable to Resolve Reference: " + reference.$ref);
+    }
+
+    private setSchemata(schemata: any, schema?: SchemaObject | ReferenceObject) {
+        if (schema) {
+            if (isRefObj(schema)) {
+                schema = this.resolveReference(schema);
+            }
+            if (schema.type === "object" && schema.title) {
+                schemata[schema.title] = schema;
+                Object.values(schema.properties || {}).forEach(value => this.setSchemata(schemata, value));
+            }
+            schema.allOf?.forEach(value => this.setSchemata(schemata, value));
+            schema.anyOf?.forEach(value => this.setSchemata(schemata, value));
+            schema.oneOf?.forEach(value => this.setSchemata(schemata, value));
+            this.setSchemata(schemata, schema.items);
+        }
+    }
+
+    protected toMethod(context: TemplateContext, kebubName: string, method: string, path: PathItemObject, operation: OperationObject): TemplateApiMethod {
+        const parameter: TemplateApiParam[] = [];
+
+        if (operation.parameters) {
+            operation.parameters.forEach(value => {
+                if (isRefObj(value)) {
+                    this.resolveReference(value);
+                } else if (value.in === "query") {
+                    parameter.push({ type: { type: "string" }, name: value.name });
+                    this.setSchemata(context.schemata, value.schema);
+                }
+            });
+        }
+        if (operation.requestBody && !(isRefObj(operation.requestBody))) {
+            const typeObject: MediaTypeObject = operation.requestBody.content["application/json"]
+
+            if (typeObject && typeObject.schema) {
+                const schema = isRefObj(typeObject.schema)
+                    ? this.resolveReference(typeObject.schema)
+                    : typeObject.schema;
+
+                if (schema.title) {
+                    parameter.push({ type: { type: "string" }, name: schema.title });
+                    this.setSchemata(context.schemata, schema);
+                }
+            }
+        }
+        let returnType = null;
+        if (!isRefObj(operation.responses[200])
+            && operation.responses[200]?.content
+            && operation.responses[200].content["application/json"]?.schema
+            && !isRefObj(operation.responses[200].content["application/json"].schema)) {
+
+            const schema = operation.responses[200].content["application/json"].schema;
+            returnType = schema;
+
+            this.setSchemata(context.schemata, schema);
+        }
+        return {
+            name: method + kebubName,
+            method,
+            description: (path.description || "") + "\n" + (operation.description || ""),
+            parameter,
+            returnType,
+        };
+    }
+
+    protected abstract createContext(): TemplateContext;
+
+    public async generate(): Promise<void> {
+        const context = this.createContext()
+        const content = await fs.readFile("./src/server/bin/misc/openapi/webclient.ts.handlebars", { encoding: "utf-8" });
+        const template = handlebars.compile(content);
+        const output = template(context);
+        await fs.writeFile("./src/server/bin/misc/openapi/webclient.ts", output, { encoding: "utf-8" });
+    }
+}
+
+class JSWebClientGenerator extends TemplateGenerator {
+    private keyReg = /\/+/g;
+    private validKeyReg = /^[a-z_][a-zA-Z_0-9]*$/;
+
+    public constructor(data: Readonly<OpenApiObject>) {
+        super(data, "./src/server/bin/misc/openapi/webclient.ts.handlebars", "./src/server/bin/misc/openapi/webclient.ts");
+        this.addHelper();
+    }
+
+    private schemaToJSType(schema?: SchemaObject): string | handlebars.SafeString {
         if (!schema) {
             return "unknown";
         } else if (schema.type === "Array") {
-            if (schema.items && "$ref" in schema.items) {
-                return "unknown[]";
+            let items = schema.items;
+
+            if (isRefObj(items)) {
+                items = this.resolveReference(items);
             }
-            const genericType = schemaToJSType(schema.items);
+            const genericType = this.schemaToJSType(items);
 
             if (genericType.toString().match(/^\w+$/)) {
                 return new handlebars.SafeString(`${genericType}[]`);
@@ -53,127 +167,73 @@ export async function generateWebClient(data: OpenApiObject): Promise<void> {
         } else if (schema.type === "object") {
             return schema.title || "any";
         } else if (schema.type === "Union") {
-            return schema.anyOf ? schema.anyOf.map(v => isRefObj(v) ? v.$ref : schemaToJSType(v)).join(" | ") : "unknown";
+            return schema.anyOf ? schema.anyOf.map(v => isRefObj(v) ? v.$ref : this.schemaToJSType(v)).join(" | ") : "unknown";
         }
         return new handlebars.SafeString(schema.type || "unknown");
     }
 
-    handlebars.registerHelper("toKey", (key: string) => {
-        return key.replace(keyReg, "_").slice(1);
-    });
+    private addHelper() {
+        handlebars.registerHelper("toKey", (key: string) => {
+            return key.replace(this.keyReg, "_").slice(1);
+        });
 
-    handlebars.registerHelper("objectAccess", (key: string) => {
-        key = key.replace(keyReg, "_").slice(1);
-        return new handlebars.SafeString(validKeyReg.test(key) ? "." + key : `["${key}"]`);
-    });
+        handlebars.registerHelper("objectAccess", (key: string) => {
+            key = key.replace(this.keyReg, "_").slice(1);
+            return new handlebars.SafeString(this.validKeyReg.test(key) ? "." + key : `["${key}"]`);
+        });
 
-    handlebars.registerHelper("toParameter", (param: TemplateApiParam[]) => {
-        return new handlebars.SafeString(param.map(value => `${value.name}: ${schemaToJSType(value.type)}`).join(", "));
-    });
+        handlebars.registerHelper("toParameter", (param: TemplateApiParam[]) => {
+            return new handlebars.SafeString(param.map(value => `${value.name}: ${this.schemaToJSType(value.type)}`).join(", "));
+        });
 
-    handlebars.registerHelper("toQueryParam", (param: TemplateApiParam[]) => {
-        if (!param.length) {
-            return "";
-        }
-        return new handlebars.SafeString(", { " + param.map(value => value.name).join(", ") + " }");
-    });
-
-    handlebars.registerHelper("toProperty", (property: string, schema: SchemaObject) => {
-        return new handlebars.SafeString(`${property}: ${schemaToJSType(schema).toString()};`);
-    });
-
-    handlebars.registerHelper("toReturnType", (returnType?: SchemaObject) => {
-        return schemaToJSType(returnType);
-    });
-
-    const context: TemplateContext = {
-        paths: [],
-        schemata: {},
-    }
-
-    for (const [key, path] of Object.entries(data.paths)) {
-        const kebubName = key
-            .split(keyReg)
-            .filter(s => s).map(s => s.slice(0, 1).toUpperCase() + s.slice(1))
-            .join("");
-
-        const templatePath: TemplateApiPath = {
-            path: key,
-            methods: []
-        };
-
-        if (path.delete) {
-            templatePath.methods.push(toMethod(context, kebubName, "delete", path, path.delete));
-        }
-        if (path.get) {
-            templatePath.methods.push(toMethod(context, kebubName, "get", path, path.get));
-        }
-        if (path.post) {
-            templatePath.methods.push(toMethod(context, kebubName, "post", path, path.post));
-        }
-        if (path.put) {
-            templatePath.methods.push(toMethod(context, kebubName, "put", path, path.put));
-        }
-        context.paths.push(templatePath);
-    }
-
-    const content = await fs.readFile("./src/server/bin/misc/openapi/webclient.ts.handlebars", { encoding: "utf-8" });
-    const template = handlebars.compile(content);
-    const output = template(context);
-    await fs.writeFile("./src/server/bin/misc/openapi/webclient.ts", output, { encoding: "utf-8" });
-}
-
-function toMethod(context: TemplateContext, kebubName: string, method: string, path: PathItemObject, operation: OperationObject): TemplateApiMethod {
-    const parameter: TemplateApiParam[] = [];
-
-    if (operation.parameters) {
-        operation.parameters.forEach(value => {
-            if (isRefObj(value)) {
-                (value as ReferenceObject).$ref
-            } else if (value.in === "query") {
-                parameter.push({ type: {type: "string"}, name: value.name });
-                setSchemata(context.schemata, value.schema);
+        handlebars.registerHelper("toQueryParam", (param: TemplateApiParam[]) => {
+            if (!param.length) {
+                return "";
             }
+            return new handlebars.SafeString(", { " + param.map(value => value.name).join(", ") + " }");
+        });
+
+        handlebars.registerHelper("toProperty", (property: string, schema: SchemaObject) => {
+            return new handlebars.SafeString(`${property}: ${this.schemaToJSType(schema).toString()};`);
+        });
+
+        handlebars.registerHelper("toReturnType", (returnType?: SchemaObject) => {
+            return this.schemaToJSType(returnType);
         });
     }
-    if (operation.requestBody && !(isRefObj(operation.requestBody))) {
-        const typeObject: MediaTypeObject = operation.requestBody.content["application/json"]
 
-        if (typeObject && typeObject.schema && !(isRefObj(typeObject.schema)) && typeObject.schema.title) {
-            parameter.push({ type: {type: "string"}, name: typeObject.schema.title });
-            setSchemata(context.schemata, typeObject.schema);
+    protected createContext(): TemplateContext {
+        const context: TemplateContext = {
+            paths: [],
+            schemata: {},
         }
-    }
-    let returnType = null;
-    if (!isRefObj(operation.responses[200])
-        && operation.responses[200]?.content
-        && operation.responses[200].content["application/json"]?.schema
-        && !isRefObj(operation.responses[200].content["application/json"].schema)) {
 
-        const schema = operation.responses[200].content["application/json"].schema;
-        returnType = schema;
+        for (const [key, path] of Object.entries(this.root.paths)) {
+            const kebubName = key
+                .split(this.keyReg)
+                .filter(s => s).map(s => s.slice(0, 1).toUpperCase() + s.slice(1))
+                .join("");
 
-        setSchemata(context.schemata, schema);
-    }
-    return {
-        name: method + kebubName,
-        method,
-        description: (path.description || "") + "\n" + (operation.description || ""),
-        parameter,
-        returnType,
-    };
-}
+            const templatePath: TemplateApiPath = {
+                path: key,
+                methods: []
+            };
 
-function setSchemata(schemata: any, schema?: SchemaObject | ReferenceObject) {
-    if (schema && !(isRefObj(schema))) {
-        if (schema.type === "object" && schema.title) {
-            schemata[schema.title] = schema;
-            Object.values(schema.properties || {}).forEach(value => setSchemata(schemata, value));
+            if (path.delete) {
+                templatePath.methods.push(this.toMethod(context, kebubName, "delete", path, path.delete));
+            }
+            if (path.get) {
+                templatePath.methods.push(this.toMethod(context, kebubName, "get", path, path.get));
+            }
+            if (path.post) {
+                templatePath.methods.push(this.toMethod(context, kebubName, "post", path, path.post));
+            }
+            if (path.put) {
+                templatePath.methods.push(this.toMethod(context, kebubName, "put", path, path.put));
+            }
+            context.paths.push(templatePath);
         }
-        schema.allOf?.forEach(value => setSchemata(schemata, value));
-        schema.anyOf?.forEach(value => setSchemata(schemata, value));
-        schema.oneOf?.forEach(value => setSchemata(schemata, value));
-        setSchemata(schemata, schema.items);
+        return context;
     }
 }
 

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -1,0 +1,163 @@
+import handlebars from "handlebars";
+import fs from "fs/promises";
+import { 
+    OpenApiObject,
+    OperationObject,
+    PathItemObject,
+    ReferenceObject,
+    MediaTypeObject
+} from "./types";
+import yaml from "js-yaml";
+
+interface TemplateApiPath {
+    path: string;
+    methods: TemplateApiMethod[];
+}
+
+interface TemplateApiMethod {
+    name: string;
+    method: string;
+    description: string;
+    parameter: TemplateApiParam[];
+    returnType: any;
+}
+
+interface TemplateApiParam {
+    type: any;
+    name: string;
+}
+
+interface TemplateContext {
+    paths: TemplateApiPath[];
+    schemata: Record<string, any>;
+}
+
+export async function generateWebClient(data: OpenApiObject): Promise<void> {
+    const keyReg = /\/+/g;
+    const validKeyReg = /^[a-z_][a-zA-Z_0-9]*$/;
+
+    handlebars.registerHelper("toKey", (key: string) => {
+        return key.replace(keyReg, "_").slice(1);
+    });
+
+    handlebars.registerHelper("objectAccess", (key: string) => {
+        key = key.replace(keyReg, "_").slice(1);
+        return new handlebars.SafeString(validKeyReg.test(key) ? "." + key : `["${key}"]`);
+    });
+
+    handlebars.registerHelper("toParameter", (param: TemplateApiParam[]) => {
+        return new handlebars.SafeString(param.map(value => `${value.name}: string`).join(", "));
+    });
+
+    handlebars.registerHelper("toQueryParam", (param: TemplateApiParam[]) => {
+        if (!param.length) {
+            return "";
+        }
+        return new handlebars.SafeString(", { " + param.map(value => value.name).join(", ") + " }");
+    });
+
+    handlebars.registerHelper("toReturnType", (returnType?: any) => {
+        if (!returnType) {
+            return "unknown";
+        } else if (returnType.type === "Array") {
+            return new handlebars.SafeString("any[]");
+        } else if (returnType.type === "object") {
+            return "any";
+        }
+        return new handlebars.SafeString(returnType.type || "unknown");
+    });
+
+    const context: TemplateContext = {
+        paths: [],
+        schemata: [],
+    }
+
+    for (const [key, path] of Object.entries(data.paths)) {
+        const kebubName = key
+            .split(keyReg)
+            .filter(s => s).map(s => s.slice(0, 1).toUpperCase() + s.slice(1))
+            .join("");
+
+        const templatePath: TemplateApiPath = {
+            path: key,
+            methods: []
+        };
+
+        if (path.delete) {
+            templatePath.methods.push(toMethod(context, kebubName, "delete", path, path.delete));
+        }
+        if (path.get) {
+            templatePath.methods.push(toMethod(context, kebubName, "get", path, path.get));
+        }
+        if (path.post) {
+            templatePath.methods.push(toMethod(context, kebubName, "post", path, path.post));
+        }
+        if (path.put) {
+            templatePath.methods.push(toMethod(context, kebubName, "put", path, path.put));
+        }
+        context.paths.push(templatePath);
+    }
+
+    const content = await fs.readFile("./src/server/bin/misc/openapi/webclient.ts.handlebars", { encoding: "utf-8" });
+    const template = handlebars.compile(content);
+    const output = template(context);
+    await fs.writeFile("./src/server/bin/misc/openapi/webclient.ts", output, { encoding: "utf-8" });
+}
+
+function toMethod(context: TemplateContext, kebubName: string, method: string, path: PathItemObject, operation: OperationObject): TemplateApiMethod {
+    const parameter: TemplateApiParam[] = [];
+
+    if (operation.parameters) {
+        operation.parameters.forEach(value => {
+            if (isRefObj(value)) {
+                (value as ReferenceObject).$ref
+            } else if (value.in === "query") {
+                parameter.push({ type: "", name: value.name });
+
+                if (value.schema && !(isRefObj(value.schema)) && value.schema.type === "object" && value.schema.title) {
+                    context.schemata[value.schema.title] = value.schema;
+                }
+            }
+        });
+    }
+    if (operation.requestBody && !(isRefObj(operation.requestBody))) {
+        const typeObject: MediaTypeObject = operation.requestBody.content["application/json"]
+
+        if (typeObject && typeObject.schema && !(isRefObj(typeObject.schema)) && typeObject.schema.title) {
+            parameter.push({ type: "", name: typeObject.schema.title });
+
+            if (typeObject.schema.type === "object") {
+                context.schemata[typeObject.schema.title] = typeObject.schema;
+            }
+        }
+    }
+    let returnType = null;
+    if (!isRefObj(operation.responses[200])
+        && operation.responses[200]?.content
+        && operation.responses[200].content["application/json"]?.schema
+        && !isRefObj(operation.responses[200].content["application/json"].schema)) {
+
+        const schema = operation.responses[200].content["application/json"].schema;
+        returnType = schema;
+
+        if (schema.type === "object" && schema.title) {
+            context.schemata[schema.title] = schema;
+        }
+    }
+    return {
+        name: method + kebubName,
+        method,
+        description: (path.description || "") + "\n" + (operation.description || ""),
+        parameter,
+        returnType,
+    };
+}
+
+function isRefObj(value: any): value is ReferenceObject {
+    return value && "$ref" in value;
+}
+
+export async function generateOpenApiSpec(data: OpenApiObject): Promise<void> {
+    const templateResult = yaml.dump(data);
+    await fs.writeFile("./result.yaml", templateResult, { encoding: "utf8" });
+}

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -228,6 +228,8 @@ class JSWebClientGenerator extends TemplateGenerator {
                     ? "string"
                     : this.schemaToJSType(valueSchema as SchemaObject);
             return new handlebars.SafeString(`Record<${this.schemaToJSType(keyType)}, ${valueType}>`);
+        } else if (schema.type === "integer") {
+            return "number";
         }
         return new handlebars.SafeString(schema.type || "unknown");
     }

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -164,10 +164,10 @@ abstract class TemplateGenerator {
 
     public async generate(): Promise<void> {
         const context = this.createContext();
-        const content = await fs.readFile("./src/server/bin/misc/openapi/webclient.ts.handlebars", { encoding: "utf-8" });
+        const content = await fs.readFile(this.templateSource, { encoding: "utf-8" });
         const template = handlebars.compile(content);
         const output = template(context);
-        await fs.writeFile("./src/server/bin/misc/openapi/webclient.ts", output, { encoding: "utf-8" });
+        await fs.writeFile(this.templateTarget, output, { encoding: "utf-8" });
     }
 }
 

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -174,6 +174,8 @@ class JSWebClientGenerator extends TemplateGenerator {
             return schema.title || "unknown";
         } else if (schema.type === "Union") {
             return schema.anyOf ? schema.anyOf.map(v => isRefObj(v) ? v.$ref : this.schemaToJSType(v)).join(" | ") : "unknown";
+        } else if (schema.type === "string" && schema.format === "date-time") {
+            return "Date";
         }
         return new handlebars.SafeString(schema.type || "unknown");
     }

--- a/src/server/bin/misc/openapi/transformer.ts
+++ b/src/server/bin/misc/openapi/transformer.ts
@@ -253,13 +253,14 @@ class JSWebClientGenerator extends TemplateGenerator {
         });
 
         handlebars.registerHelper("toQueryParam", (param: TemplateApiParam[]) => {
+            param = param.filter(value => !autoIncluded.includes(value.name));
+
             if (!param.length) {
                 return "";
             }
             return new handlebars.SafeString(
                 ", { " + 
                 param
-                    .filter(value => !autoIncluded.includes(value.name))
                     .map(value => value.name)
                     .join(", ") + 
                 " }"

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -353,3 +353,4 @@ export interface ContactObject {
 }
 
 export const enumNameSymbol = Symbol("enumName");
+export const keyTypeSymbol = Symbol("keyType");

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -214,7 +214,7 @@ export interface SchemaObject {
      */
     format?: string;
     default?: any;
-    nullable?: string;
+    nullable?: boolean;
     discriminator?: DiscriminatorObject;
     readOnly?: boolean;
     writeOnly?: boolean;

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -351,3 +351,5 @@ export interface ContactObject {
     url?: string;
     email?: string;
 }
+
+export const enumNameSymbol = Symbol("enumName");

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -152,6 +152,14 @@ export interface SchemaObject {
      */
     exclusiveMaximum?: number;
     /**
+     * for type number
+     */
+    minimum?: number;
+    /**
+     * for type number
+     */
+    exclusiveMinimum?: number;
+    /**
      * for type string
      */
     maxLength?: number;

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -193,7 +193,7 @@ export interface SchemaObject {
     oneOf?: Array<SchemaObject | ReferenceObject>;
     not?: Array<SchemaObject | ReferenceObject>;
     items?: Array<SchemaObject | ReferenceObject>;
-    properties?: { [property: string]: SchemaObject | ReferenceObject };
+    properties?: Record<string, SchemaObject | ReferenceObject>;
     additionalProperties?: boolean | SchemaObject | ReferenceObject;
     description?: string;
     /**
@@ -339,7 +339,7 @@ export interface InfoObject {
     version: string;
 }
 
-export type ApiMap<T> = Record<string, T> | Map<string, T>;
+export type ApiMap<T> = Record<string, T>;
 
 export interface LicenseObject {
     name: string;

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -192,7 +192,7 @@ export interface SchemaObject {
     anyOf?: Array<SchemaObject | ReferenceObject>;
     oneOf?: Array<SchemaObject | ReferenceObject>;
     not?: Array<SchemaObject | ReferenceObject>;
-    items?: Array<SchemaObject | ReferenceObject>;
+    items?: SchemaObject | ReferenceObject;
     properties?: Record<string, SchemaObject | ReferenceObject>;
     additionalProperties?: boolean | SchemaObject | ReferenceObject;
     description?: string;

--- a/src/server/bin/misc/openapi/types.ts
+++ b/src/server/bin/misc/openapi/types.ts
@@ -1,0 +1,353 @@
+/**
+ * OpenApi v3 Specification.
+ */
+export interface OpenApiObject {
+    /**
+     * Semantic OpenApi Version
+     */
+    openapi: string;
+    info: InfoObject;
+    servers?: ServerObject[];
+    paths: PathsObject;
+    components?: ComponentsObject;
+    security?: SecurityRequirementObject[];
+    tags?: TagObject[];
+    externalDocs?: ExternalDocumentationObject;
+}
+
+export interface ExternalDocumentationObject {
+    description?: string;
+    url: string;
+}
+
+export interface TagObject {
+    name: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+}
+
+export interface SecurityRequirementObject {
+    [securitySchemeName: string]: string[];
+}
+
+/**
+ * Requirement on string keys: '^[a-zA-Z0-9\.\-_]+$'.
+ */
+export interface ComponentsObject {
+    schemas?: ApiMap<SchemaObject | ReferenceObject>;
+    responses?: ApiMap<ResponseObject | ReferenceObject>;
+    parameters?: ApiMap<ExampleObject | ReferenceObject>;
+    requestBodies?: ApiMap<RequestBodyObject | ReferenceObject>;
+    headers?: ApiMap<HeaderObject | ReferenceObject>;
+    securitySchemes?: ApiMap<SecuritySchemeObject | ReferenceObject>;
+    links?: ApiMap<LinkObject | ReferenceObject>;
+    callbacks?: ApiMap<CallbackObject | ReferenceObject>;
+}
+
+export interface CallbackObject {
+    [expression: string]: PathItemObject;
+}
+
+export interface LinkObject {
+    operationRef?: string;
+    operationId?: string;
+    parameters?: ApiMap<any | string>;
+    requestBody?: any | string;
+    description?: string;
+    server?: ServerObject;
+}
+
+export interface SecuritySchemeObject {
+    type: "apiKey" | "http" | "oauth2" | "openIdConnect";
+    description?: string;
+}
+
+export interface ApikeySecuritySchemeObject extends SecuritySchemeObject {
+    type: "apiKey";
+    name: string;
+    in: "query" | "header" | "cookie";
+}
+
+export interface HttpSecuritySchemeObject extends SecuritySchemeObject {
+    type: "http";
+    scheme: string;
+    bearerFormat?: string;
+}
+
+export interface OAuth2SecuritySchemeObject extends SecuritySchemeObject {
+    type: "oauth2";
+    flows: OAuthFlowsObject;
+}
+
+export interface OAuthFlowsObject {
+    implicit?: OAuthFlowObject;
+    password?: OAuthFlowObject;
+    clientCredentials?: OAuthFlowObject;
+    authorizationCode?: OAuthFlowObject;
+}
+
+export interface OAuthFlowObject {
+    authorizationUrl: string;
+    tokenUrl: string;
+    refreshUrl?: string;
+    scopes: ApiMap<string>;
+}
+
+export interface OpenIdConnectSecuritySchemeObject extends SecuritySchemeObject {
+    type: "openIdConnect";
+    openIdConnectUrl: string;
+}
+
+export interface HeaderObject {
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    allowEmptyValue?: boolean;
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+    schema?: SchemaObject | ReferenceObject;
+    example?: any;
+    examples?: ApiMap<ExampleObject | ReferenceObject>;
+    content?: ApiMap<MediaTypeObject>;
+}
+
+export interface RequestBodyObject {
+    description?: string;
+    content: ApiMap<MediaTypeObject>;
+    required?: boolean;
+}
+
+export interface ExampleObject {
+    summary?: string;
+    description?: string;
+    value?: any;
+    externalValue?: string;
+}
+
+export interface ResponseObject {
+    description: string;
+    headers?: ApiMap<HeaderObject | ReferenceObject>;
+    content?: ApiMap<MediaTypeObject>;
+    links?: ApiMap<LinkObject | ReferenceObject>;
+}
+
+export interface ReferenceObject {
+    $ref: string;
+}
+
+export interface SchemaObject {
+    type: string;
+    title?: string;
+    /**
+     * for type number
+     */
+    multipleOf?: number;
+    /**
+     * for type number
+     */
+    maximum?: number;
+    /**
+     * for type number
+     */
+    exclusiveMaximum?: number;
+    /**
+     * for type string
+     */
+    maxLength?: number;
+    /**
+     * for type string
+     */
+    minLength?: number;
+    /**
+     * for type string
+     */
+    pattern?: RegExp;
+    /**
+     * for type array
+     */
+    maxItems?: number;
+    /**
+     * for type array
+     */
+    minItems?: number;
+    /**
+     * for type array
+     */
+    uniqueItems?: boolean;
+    /**
+     * for type object
+     */
+    maxProperties?: number;
+    /**
+     * for type object
+     */
+    minProperties?: number;
+    /**
+     * for type object
+     */
+    required?: string[];
+    enum?: any[];
+    allOf?: Array<SchemaObject | ReferenceObject>;
+    anyOf?: Array<SchemaObject | ReferenceObject>;
+    oneOf?: Array<SchemaObject | ReferenceObject>;
+    not?: Array<SchemaObject | ReferenceObject>;
+    items?: Array<SchemaObject | ReferenceObject>;
+    properties?: { [property: string]: SchemaObject | ReferenceObject };
+    additionalProperties?: boolean | SchemaObject | ReferenceObject;
+    description?: string;
+    /**
+     * <table>
+     *     <tr><th>type</th>    <th>format</th> <th>Comments</th></tr>
+     *     <tr><td>integer</td> <td>int32</td>    <td>signed 32 bits</td></tr>
+     *     <tr><td>integer</td> <td>int64</td>    <td>signed 64 bits (a.k.a long)</td></tr>
+     *     <tr><td>number</td>    <td>float</td>  <td></td></tr>
+     *     <tr><td>number</td>    <td>double</td> <td></td></tr>
+     *     <tr><td>string</td>  <td></td>       <td></td></tr>
+     *     <tr><td>string</td>    <td>byte</td>    <td>base64 encoded characters</td></tr>
+     *     <tr><td>string</td>    <td>binary</td> <td>any sequence of octets</td></tr>
+     *     <tr><td>boolean</td> <td></td>       <td></td></tr>
+     *     <tr><td>string</td>    <td>date</td>    <td>As defined by full-date - [RFC3339]</td></tr>
+     *     <tr><td>string</td>    <td>date-time</td>    <td>As defined by date-time - [RFC3339]</td></tr>
+     *     <tr><td>string</td>    <td>password</td>    <td>A hint to UIs to obscure input.</td></tr>
+     * </table>
+     */
+    format?: string;
+    default?: any;
+    nullable?: string;
+    discriminator?: DiscriminatorObject;
+    readOnly?: boolean;
+    writeOnly?: boolean;
+    xml?: XMLObject;
+    externalDocs?: ExternalDocumentationObject;
+    example?: any;
+    deprecated?: boolean;
+}
+
+export interface XMLObject {
+    name?: string;
+    namespace?: string;
+    prefix?: string;
+    attribute?: boolean;
+    wrapped?: boolean;
+}
+
+export interface DiscriminatorObject {
+    propertyName: string;
+    mapping?: ApiMap<string>;
+}
+
+/**
+ * Path must begin with '/'.
+ */
+export interface PathsObject {
+    [path: string]: PathItemObject;
+}
+
+export interface PathItemObject {
+    /**
+     * Exmaple: #/components/schemas/Pet
+     */
+    $ref?: string;
+    summary?: string;
+    description?: string;
+    get?: OperationObject;
+    put?: OperationObject;
+    post?: OperationObject;
+    delete?: OperationObject;
+    options?: OperationObject;
+    head?: OperationObject;
+    patch?: OperationObject;
+    trace?: OperationObject;
+    servers?: ServerObject[];
+    parameters?: Array<ParameterObject | ReferenceObject>;
+}
+
+export interface ParameterObject {
+    name: string;
+    in: "query" | "header" | "path" | "cookie";
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    allowEmptyValue?: boolean;
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+    schema?: SchemaObject | ReferenceObject;
+    example?: any;
+    examples?: ApiMap<ExampleObject | ReferenceObject>;
+    content?: ApiMap<MediaTypeObject>;
+}
+
+export interface MediaTypeObject {
+    schema?: SchemaObject | ReferenceObject;
+    example?: any;
+    examples?: ApiMap<ExampleObject | ReferenceObject>;
+    encoding?: ApiMap<EncodingObject>;
+}
+
+export interface EncodingObject {
+    contentType?: string;
+    headers?: ApiMap<HeaderObject | ReferenceObject>;
+    style?: string;
+    explode?: string;
+    allowReserved?: string;
+}
+
+export interface OperationObject {
+    tags?: string[];
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+    operationId?: string;
+    parameters?: Array<ParameterObject | ReferenceObject>;
+    requestBody?: RequestBodyObject | ReferenceObject;
+    responses: ResponsesObject;
+    callbacks?: ApiMap<CallbackObject | ReferenceObject>;
+    deprecated?: boolean;
+    security?: SecurityRequirementObject[];
+    server?: ServerObject[];
+}
+
+export interface ResponsesObject {
+    default?: ResponseObject | ReferenceObject;
+
+    [code: number]: ResponseObject | ReferenceObject;
+}
+
+export interface ServerObject {
+    url: string;
+    description?: string;
+    variables?: ApiMap<ServerVariableObject>;
+}
+
+export interface ServerVariableObject {
+    enum?: string[];
+    default: string;
+    description?: string;
+}
+
+export interface InfoObject {
+    title: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: ContactObject;
+    license?: LicenseObject;
+    /**
+     * Version of the specific Document
+     */
+    version: string;
+}
+
+export type ApiMap<T> = Record<string, T> | Map<string, T>;
+
+export interface LicenseObject {
+    name: string;
+    url?: string;
+}
+
+export interface ContactObject {
+    name?: string;
+    url?: string;
+    email?: string;
+}

--- a/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
+++ b/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
@@ -1,6 +1,6 @@
 import { Request } from "express-serve-static-core";
 
-{{#each schemata}}
+{{#each (filterByParam schemata paths)}}
 {{#if (isType . "object")}}
 export interface {{@key}} {
 {{#each properties}}
@@ -17,7 +17,7 @@ export enum {{@key}} {
 {{/if}}
 {{/each}}
 
-{{#each schemata}}
+{{#each (filterByParam schemata paths)}}
 
 function to{{camelCase @key}}(value: any): {{@key}} | null {
 {{#if (isType . "object")}}

--- a/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
+++ b/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
@@ -1,0 +1,135 @@
+import { Request } from "express-serve-static-core";
+
+{{#each schemata}}
+{{#if (isType . "object")}}
+export interface {{@key}} {
+{{#each properties}}
+    {{toProperty @key . ../required}}
+{{/each}}
+}
+{{/if}}
+{{#if (isType . "Enum")}}
+export enum {{@key}} {
+{{#each enum}}
+    {{toEnumMember . @index ../enum}}
+{{/each}}
+}
+{{/if}}
+{{/each}}
+
+{{#each schemata}}
+
+function to{{camelCase @key}}(value: any): {{@key}} | null {
+    return null;
+}
+{{/each}}
+
+function isString(value: any): value is string {
+    return Object.prototype.toString.call(value) === "[object String]";
+}
+
+function toString(value: string): string {
+    return value;
+}
+
+function toNumber(value: any): number | null {
+    if (isString(value)) {
+        value = Number(value);
+
+        if (!Number.isNaN(value)) {
+            return value;
+        }
+    } else if (typeof value === "number") {
+        return value;
+    }
+    return null;
+}
+
+function toBoolean(value: any): boolean | null {
+    if (isString(value)) {
+        return value === "true";
+    } else if (typeof value === "boolean") {
+        return value;
+    }
+    return null;
+}
+
+function toDate(value: any): Date | null {
+    if (isString(value)) {
+        value = new Date(value);
+
+        if (!Number.isNaN(value.getTime())) {
+            return value;
+        }
+    }
+    return null;
+}
+
+function toArray(value: any): any[] | null {
+    if (isString(value)) {
+        const s = value.trim();
+        if (!s.startsWith("[") || !s.endsWith("]")) {
+            return [];
+        }
+        return s
+            .split(/[[\],]/)
+            .map(split => Number(split))
+            .filter((n: number) => !Number.isNaN(n) && n);
+    } else if (Array.isArray(value)) {
+        return value;
+    } else {
+        return null;
+    }
+}
+
+{{#each paths}}
+{{#each methods}}
+{{#if parameter.length}}
+export function to{{camelCase name}}(req: Request): {{paramToReturnType parameter}} | null {
+    const result: any = {};
+{{#each parameter}}
+{{#if (is type.type "Union")}}
+{{#each type.oneOf}}
+    if (result.{{../name}} == null) {
+    {{#if (is ../../method "get")}}
+        result.{{../name}} = {{toConvertName .}}(req.query.{{../name}});
+    {{else}}
+        result.{{../name}} = {{toConvertName .}}(req.body.{{../name}});
+    {{/if}}
+{{#if (is type "Array")}}
+        if (result.{{../name}}) {
+            result.{{../name}} = result.{{../name}}.map({{toConvertName items}});
+
+            if (result.some((v: any | null) => v == null)) {
+                return null;
+            }
+        }
+{{/if}}
+    }
+{{/each}}
+    if (result.{{name}} == null) {
+        return null;
+    }
+{{else}}
+{{#if (is ../method "get")}}
+    result.{{name}} = {{toConvertName type}}(req.query.{{name}});
+{{else}}
+    result.{{name}} = {{toConvertName type}}(req.body.{{name}});
+{{/if}}
+    if (result.{{name}} == null) {
+        return null;
+    }
+{{#if (is type.type "Array")}}
+    result.{{name}} = result.{{name}}.map({{toConvertName type.items}});
+
+    if (result.some((v: any | null) => v == null)) {
+        return null;
+    }
+{{/if}}
+{{/if}}
+{{/each}}
+    return result;
+}
+{{/if}}
+{{/each}}
+{{/each}}

--- a/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
+++ b/src/server/bin/misc/openapi/validateMiddleware.ts.handlebars
@@ -20,7 +20,20 @@ export enum {{@key}} {
 {{#each schemata}}
 
 function to{{camelCase @key}}(value: any): {{@key}} | null {
+{{#if (isType . "object")}}
+    {{> toObject type=. variable="value"}}
+    return value;
+{{else if (isType . "Enum")}}
+{{#each enum}}
+    if (value === {{toTSValue .}}) {
+        return {{@../key}}.{{findEnumMember . ../enum}};
+    }
+{{/each}}
     return null;
+{{else}}
+    console.log("No validation for Schema '{{@key}}' implemented, always invalid.");
+    return null;
+{{/if}}
 }
 {{/each}}
 
@@ -28,8 +41,11 @@ function isString(value: any): value is string {
     return Object.prototype.toString.call(value) === "[object String]";
 }
 
-function toString(value: string): string {
-    return value;
+function toString(value: unknown): string | null {
+    if (isString(value)) {
+        return value;
+    }
+    return null;
 }
 
 function toNumber(value: any): number | null {

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -8,11 +8,20 @@ const Methods: { post: string; get: string; put: string; delete: string } = {
     delete: "DELETE",
 };
 {{#each schemata}}
+{{#if (isType . "object")}}
 interface {{@key}} {
 {{#each properties}}
     {{toProperty @key .}}
 {{/each}}
 }
+{{/if}}
+{{#if (isType . "Enum")}}
+enum {{@key}} {
+{{#each enum}}
+    {{toEnumMember . @index ../enum}}
+{{/each}}
+}
+{{/if}}
 {{/each}}
 
 const api = {

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -68,7 +68,7 @@ export const HttpClient = {
     {{#each paths}}
     {{#each methods}}
 
-    {{name}}({{toParameter parameter}}): Promise<{{toReturnType returnType}}> {
+    {{name}}({{toParameter parameter}}): Promise<{{toType returnType}}> {
         return this.queryServer(api{{objectAccess ../path}}.{{method}}{{toQueryParam parameter}});
     },
     {{/each}}

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -9,7 +9,9 @@ const Methods: { post: string; get: string; put: string; delete: string } = {
 };
 {{#each schemata}}
 interface {{@key}} {
-
+{{#each properties}}
+    {{toProperty @key .}}
+{{/each}}
 }
 {{/each}}
 

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -11,7 +11,7 @@ const Methods: { post: string; get: string; put: string; delete: string } = {
 {{#if (isType . "object")}}
 interface {{@key}} {
 {{#each properties}}
-    {{toProperty @key .}}
+    {{toProperty @key . ../required}}
 {{/each}}
 }
 {{/if}}

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -30,7 +30,7 @@ const api = {
         {{#each methods}}
         {{method}}: {
             method: Methods.{{method}},
-            path: "{{../path}}"
+            path: "api{{../path}}"
         },
         {{/each}}
     },

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -1,0 +1,108 @@
+/**
+ * Allowed Methods for the API.
+ */
+const Methods: { post: string; get: string; put: string; delete: string } = {
+    post: "POST",
+    get: "GET",
+    put: "PUT",
+    delete: "DELETE",
+};
+{{#each schemata}}
+interface {{@key}} {
+
+}
+{{/each}}
+
+const api = {
+    {{#each paths}}
+    "{{toKey path}}": {
+        {{#each methods}}
+        {{method}}: {
+            method: Methods.{{method}},
+            path: "{{../path}}"
+        },
+        {{/each}}
+    },
+    {{/each}}
+};
+
+export const HttpClient = {
+    _user: null,
+    _init: false,
+
+    get userPromise(): Promise<any> {
+        return new Promise((resolve) => {
+            if (this._init) {
+                resolve(this._user);
+                return;
+            }
+            const intervalId = setInterval(() => {
+                if (this._init) {
+                    clearInterval(intervalId);
+                    resolve(this._user);
+                }
+            }, 500);
+        });
+    },
+
+    set user(user: any) {
+        this._user = user;
+        this._init = true;
+    },
+
+    get loggedIn(): boolean {
+        // @ts-ignore
+        return this.user && Boolean(this.user.uuid);
+    },
+    {{#each paths}}
+    {{#each methods}}
+
+    {{name}}({{toParameter parameter}}): Promise<{{toReturnType returnType}}> {
+        return this.queryServer(api{{objectAccess ../path}}.{{method}}{{toQueryParam parameter}});
+    },
+    {{/each}}
+    {{/each}}
+
+    async queryServer({ path, method }: { path: string; method?: string }, query?: any): Promise<any> {
+        // if path includes user, it needs to be authenticated
+        if (path.includes("user")) {
+            const user = await this.userPromise;
+            // @ts-ignore
+            if (!user || !user.uuid) {
+                throw Error("cannot send user message if no user is logged in");
+            }
+            if (!query) {
+                query = {};
+            }
+            // @ts-ignore
+            query.uuid = user.uuid;
+            // @ts-ignore
+            query.session = user.session;
+        }
+        const init = {
+            method,
+            headers: {
+                "Content-Type": "application/json; charset=utf-8",
+            },
+        };
+        // @ts-expect-error
+        const url = new URL(`${window.location.origin}/${path}`);
+        if (query) {
+            if (method === Methods.get) {
+                Object.keys(query).forEach((key) =>
+                    url.searchParams.append(key, query[key]),
+                );
+            } else {
+                // @ts-ignore
+                init.body = JSON.stringify(query);
+            }
+        }
+        // @ts-expect-error
+        const response = await fetch(url.toString(), init);
+        const result = await response.json();
+        if (result.error) {
+            return Promise.reject(result.error);
+        }
+        return result;
+    },
+};

--- a/src/server/bin/misc/openapi/webclient.ts.handlebars
+++ b/src/server/bin/misc/openapi/webclient.ts.handlebars
@@ -9,14 +9,14 @@ const Methods: { post: string; get: string; put: string; delete: string } = {
 };
 {{#each schemata}}
 {{#if (isType . "object")}}
-interface {{@key}} {
+export interface {{@key}} {
 {{#each properties}}
     {{toProperty @key . ../required}}
 {{/each}}
 }
 {{/if}}
 {{#if (isType . "Enum")}}
-enum {{@key}} {
+export enum {{@key}} {
 {{#each enum}}
     {{toEnumMember . @index ../enum}}
 {{/each}}

--- a/src/server/bin/types.ts
+++ b/src/server/bin/types.ts
@@ -16,7 +16,7 @@ export interface SimpleMedium {
     languageOfOrigin?: string;
     author?: string;
     title: string;
-    medium: number;
+    medium: MediaType;
     artist?: string;
     lang?: string;
     stateOrigin?: number;

--- a/src/server/bin/types.ts
+++ b/src/server/bin/types.ts
@@ -3,15 +3,15 @@ import { ScrapeType } from "./externals/types";
 import { Query } from "mysql";
 
 export interface SearchResult {
-    coverUrl?: string;
-    link: string;
+    coverUrl?: Link;
+    link: Link;
     title: string;
     author?: string;
     medium: MediaType;
 }
 
 export interface SimpleMedium {
-    id?: number;
+    id?: Id;
     countryOfOrigin?: string;
     languageOfOrigin?: string;
     author?: string;
@@ -19,8 +19,8 @@ export interface SimpleMedium {
     medium: MediaType;
     artist?: string;
     lang?: string;
-    stateOrigin?: number;
-    stateTL?: number;
+    stateOrigin?: ReleaseState;
+    stateTL?: ReleaseState;
     series?: string;
     universe?: string;
 
@@ -28,25 +28,25 @@ export interface SimpleMedium {
 }
 
 export interface SecondaryMedium {
-    id: number;
+    id: Id;
     totalEpisodes: number;
     readEpisodes: number;
     tocs: FullMediumToc[];
 }
 
 export type UpdateMedium = Partial<SimpleMedium> & {
-    id: number;
+    id: Id;
 }
 
 export interface Medium extends SimpleMedium {
-    parts?: number[];
+    parts?: Id[];
     latestReleased: number[];
-    currentRead: number;
-    unreadEpisodes: number[];
+    currentRead: Id;
+    unreadEpisodes: Id[];
 }
 
 export interface TocSearchMedium {
-    mediumId: number;
+    mediumId: Id;
     hosts?: string[];
     title: string;
     medium: MediaType;
@@ -54,8 +54,8 @@ export interface TocSearchMedium {
 }
 
 export interface MediumToc {
-    mediumId: number;
-    link: string;
+    mediumId: Id;
+    link: Link;
 }
 
 export type FullMediumToc = MediumToc & UpdateMedium;
@@ -72,13 +72,13 @@ export interface Indexable {
 }
 
 export interface MinPart extends Indexable {
-    id: number;
+    id: Id;
     title?: string;
     mediumId: number;
 }
 
 export interface Part extends MinPart {
-    episodes: Episode[] | number[];
+    episodes: Episode[] | Id[];
 }
 
 export interface FullPart extends Part {
@@ -86,12 +86,12 @@ export interface FullPart extends Part {
 }
 
 export interface ShallowPart extends Part {
-    episodes: number[];
+    episodes: Id[];
 }
 
 export interface SimpleEpisode extends Indexable {
-    id: number;
-    partId: number;
+    id: Id;
+    partId: Id;
     combiIndex?: number;
     releases: EpisodeRelease[];
 }
@@ -108,14 +108,14 @@ export interface Episode extends SimpleEpisode {
 export type PureEpisode = Omit<Episode, "releases">;
 
 export interface ReadEpisode {
-    episodeId: number;
+    episodeId: Id;
     readDate: Date;
     progress: number;
 }
 
 export interface SimpleRelease {
-    episodeId: number;
-    url: string;
+    episodeId: Id;
+    url: Link;
 }
 
 export interface EpisodeRelease extends SimpleRelease {
@@ -123,16 +123,16 @@ export interface EpisodeRelease extends SimpleRelease {
     releaseDate: Date;
     locked?: boolean;
     sourceType?: string;
-    tocId?: number;
+    tocId?: Id;
 }
 
 export type PureDisplayRelease = Omit<EpisodeRelease, "sourceType" | "tocId">
 
 export interface DisplayRelease {
-    episodeId: number;
+    episodeId: Id;
     title: string;
-    link: string;
-    mediumId: number;
+    link: Link;
+    mediumId: Id;
     locked?: boolean;
     date: Date;
     progress: number;
@@ -140,14 +140,14 @@ export interface DisplayRelease {
 
 export interface DisplayReleasesResponse {
     releases: DisplayRelease[];
-    media: Record<number, string>;
+    media: Record<Id, string>;
     latest: Date;
 }
 
 export interface MediumRelease {
-    episodeId: number;
+    episodeId: Id;
     title: string;
-    link: string;
+    link: Link;
     combiIndex: number;
     locked?: boolean;
     date: Date;
@@ -159,18 +159,18 @@ export interface MinList {
 }
 
 export type UserList = MinList & {
-    id: number;
+    id: Id;
 }
 
 export interface StorageList extends MinList {
-    id: number;
+    id: Id;
     user_uuid: Uuid;
 }
 
 export interface List extends MinList {
-    id: number;
+    id: Id;
     userUuid: Uuid;
-    items: number[];
+    items: Id[];
 }
 
 export interface UpdateUser {
@@ -186,8 +186,8 @@ export interface SimpleUser {
 }
 
 export interface User extends SimpleUser {
-    unreadNews: number[];
-    unreadChapter: number[];
+    unreadNews: Id[];
+    unreadChapter: Id[];
     readToday: ReadEpisode[];
     externalUser: ExternalUser[];
     lists: List[];
@@ -195,10 +195,10 @@ export interface User extends SimpleUser {
 
 export interface ExternalList {
     uuid?: Uuid;
-    id: number;
+    id: Id;
     name: string;
     medium: number;
-    url: string;
+    url: Link;
     items: number[];
 }
 
@@ -219,24 +219,24 @@ export type PureExternalUser = Omit<DisplayExternalUser, "lists">;
 
 export interface News {
     title: string;
-    link: string;
+    link: Link;
     date: Date;
-    id?: number;
+    id?: Id;
     read?: boolean;
-    mediumId?: number;
+    mediumId?: Id;
     mediumTitle?: number;
 }
 
 export type PureNews = Omit<News, "mediumId" | "mediumTitle">;
 
 export interface NewsResult {
-    link: string;
+    link: Link;
     rawNews: News[];
 }
 
 export interface EpisodeNews {
     mediumType: MediaType;
-    mediumTocLink?: string;
+    mediumTocLink?: Link;
     mediumTitle: string;
     partIndex?: number;
     partTotalIndex?: number;
@@ -246,35 +246,35 @@ export interface EpisodeNews {
     episodeTotalIndex: number;
     episodePartialIndex?: number;
     locked?: boolean;
-    link: string;
+    link: Link;
     date: Date;
 }
 
 export interface Synonyms {
-    mediumId: number;
+    mediumId: Id;
     synonym: string[];
 }
 
 export interface ScrapeItem {
-    link: string;
+    link: Link;
     type: ScrapeType;
     nextScrape?: Date;
-    userId?: string;
-    externalUserId?: string;
-    mediumId?: number;
+    userId?: Uuid;
+    externalUserId?: Uuid;
+    mediumId?: Id;
     info?: string;
 }
 
 export interface LikeMedium {
     medium?: SimpleMedium;
     title: string;
-    link: string;
+    link: Link;
 }
 
 export interface LikeMediumQuery {
     title: string;
-    link?: string;
-    type?: number;
+    link?: Link;
+    type?: MediaType;
 }
 
 export interface MetaResult {
@@ -283,7 +283,7 @@ export interface MetaResult {
     volIndex?: string;
     chapter?: string;
     chapIndex?: string;
-    type: string;
+    type: MediaType;
     seeAble: boolean;
 }
 
@@ -291,7 +291,7 @@ export interface Result {
     result: MetaResult | MetaResult[];
     preliminary?: boolean;
     accept?: boolean;
-    url: string;
+    url: Link;
 }
 
 export interface ProgressResult extends MetaResult {
@@ -300,7 +300,7 @@ export interface ProgressResult extends MetaResult {
 }
 
 export interface PageInfo {
-    link: string;
+    link: Link;
     key: string;
     values: string[];
 }
@@ -397,18 +397,25 @@ export type PromiseFunction = (...args: any[]) => Promise<any>;
  */
 export type PromiseFunctions<T, K extends StringKeys<T>> = Properties<Omit<T, K>, PromiseFunction>;
 
+/**
+ * Set specific properties with string keys as required.
+ */
+export type NonNull<T, K extends StringKeys<T>> = T & {
+    [S in K]-?: T[K];
+};
+
 export type Primitive = string | number | boolean;
 
 export interface Invalidation {
-    mediumId?: number;
-    partId?: number;
-    episodeId?: number;
+    mediumId?: Id;
+    partId?: Id;
+    episodeId?: Id;
     uuid: Nullable<Uuid>;
     userUuid?: boolean;
     externalUuid?: Uuid;
-    externalListId?: number;
-    listId?: number;
-    newsId?: number;
+    externalListId?: Id;
+    listId?: Id;
+    newsId?: Id;
 }
 
 export interface EpisodeContentData {
@@ -430,6 +437,16 @@ export enum ReleaseState {
  * A String in RFC UUID Format with a length of 36 characters.
  */
 export type Uuid = string;
+
+/**
+ * A String in a HTTP Url Format.
+ */
+export type Link = string;
+
+/**
+ * An Integer between 1 (inclusive) and 2^64 (inclusive?)
+ */
+export type Id = number;
 
 export enum ScrapeName {
     searchForToc = "searchForToc",
@@ -455,9 +472,9 @@ export interface JobItem {
     state: JobState;
     interval: number;
     deleteAfterRun: boolean;
-    id: number;
+    id: Id;
     name: string;
-    runAfter?: number;
+    runAfter?: Id;
     runningSince?: Date;
     nextRun?: Date;
     lastRun?: Date;
@@ -554,11 +571,11 @@ export interface ListMedia {
 }
 
 export interface DataStats {
-    media: Record<number, Record<number, { episodeCount: number; episodeSum: number; releaseCount: number }>>;
-    mediaStats: Record<number, { tocs: number }>;
-    lists: Record<number, number[]>;
-    extLists: Record<number, number[]>;
-    extUser: Record<string, number[]>;
+    media: Record<Id, Record<Id, { episodeCount: number; episodeSum: number; releaseCount: number }>>;
+    mediaStats: Record<Id, { tocs: number }>;
+    lists: Record<Id, Id[]>;
+    extLists: Record<Id, Id[]>;
+    extUser: Record<Uuid, Id[]>;
 }
 
 export interface NewData {

--- a/src/server/bin/types.ts
+++ b/src/server/bin/types.ts
@@ -105,7 +105,7 @@ export interface Episode extends SimpleEpisode {
     readDate: Nullable<Date>;
 }
 
-export type PureEpisode = Omit<Episode, "releases">
+export type PureEpisode = Omit<Episode, "releases">;
 
 export interface ReadEpisode {
     episodeId: number;
@@ -125,6 +125,8 @@ export interface EpisodeRelease extends SimpleRelease {
     sourceType?: string;
     tocId?: number;
 }
+
+export type PureDisplayRelease = Omit<EpisodeRelease, "sourceType" | "tocId">
 
 export interface DisplayRelease {
     episodeId: number;
@@ -154,6 +156,10 @@ export interface MediumRelease {
 export interface MinList {
     name: string;
     medium: number;
+}
+
+export type UserList = MinList & {
+    id: number;
 }
 
 export interface StorageList extends MinList {
@@ -196,6 +202,8 @@ export interface ExternalList {
     items: number[];
 }
 
+export type PureExternalList = Omit<ExternalList, "items">;
+
 export interface ExternalUser {
     localUuid: Uuid;
     uuid: Uuid;
@@ -207,6 +215,7 @@ export interface ExternalUser {
 }
 
 export type DisplayExternalUser = Omit<ExternalUser, "lastScrape" | "cookies">;
+export type PureExternalUser = Omit<DisplayExternalUser, "lists">;
 
 export interface News {
     title: string;
@@ -217,6 +226,8 @@ export interface News {
     mediumId?: number;
     mediumTitle?: number;
 }
+
+export type PureNews = Omit<News, "mediumId" | "mediumTitle">;
 
 export interface NewsResult {
     link: string;
@@ -535,4 +546,36 @@ export enum MilliTime {
 // @ts-expect-error
 export interface TypedQuery<Packet> extends Query {
     on(ev: "packet", callback: (packet: Packet) => void): Query;
+}
+
+export interface ListMedia {
+    list: List[] | List;
+    media: Medium[];
+}
+
+export interface DataStats {
+    media: Record<number, Record<number, { episodeCount: number; episodeSum: number; releaseCount: number }>>;
+    mediaStats: Record<number, { tocs: number }>;
+    lists: Record<number, number[]>;
+    extLists: Record<number, number[]>;
+    extUser: Record<string, number[]>;
+}
+
+export interface NewData {
+    tocs: FullMediumToc[];
+    media: SimpleMedium[];
+    releases: PureDisplayRelease[];
+    episodes: PureEpisode[];
+    parts: MinPart[];
+    lists: UserList[];
+    extLists: PureExternalList[];
+    extUser: PureExternalUser[];
+    mediaInWait: MediumInWait[];
+    news: PureNews[];
+}
+
+export interface MediumInWait {
+    title: string;
+    medium: MediaType;
+    link: string;
 }

--- a/src/server/bin/types.ts
+++ b/src/server/bin/types.ts
@@ -1,5 +1,6 @@
 import { MediaType } from "./tools";
 import { ScrapeType } from "./externals/types";
+import { Query } from "mysql";
 
 export interface SearchResult {
     coverUrl?: string;
@@ -104,6 +105,8 @@ export interface Episode extends SimpleEpisode {
     readDate: Nullable<Date>;
 }
 
+export type PureEpisode = Omit<Episode, "releases">
+
 export interface ReadEpisode {
     episodeId: number;
     readDate: Date;
@@ -202,6 +205,8 @@ export interface ExternalUser {
     lastScrape?: Date;
     cookies?: Nullable<string>;
 }
+
+export type DisplayExternalUser = Omit<ExternalUser, "lastScrape" | "cookies">;
 
 export interface News {
     title: string;
@@ -525,4 +530,9 @@ export enum MilliTime {
     MINUTE = 60000,
     HOUR = 3600000,
     DAY = 86400000
+}
+
+// @ts-expect-error
+export interface TypedQuery<Packet> extends Query {
+    on(ev: "packet", callback: (packet: Packet) => void): Query;
 }

--- a/src/server/bin/userMiddleware.ts
+++ b/src/server/bin/userMiddleware.ts
@@ -578,12 +578,12 @@ export const postEpisode: Handler = (req, res) => {
     sendResult(res, episodeStorage.addEpisode(episode));
 };
 export const putEpisode: Handler = (req, res) => {
-    const { episode, uuid } = req.body;
+    const { episode } = req.body;
     if (!episode || (Array.isArray(episode) && !episode.length)) {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
     }
-    sendResult(res, episode.updateEpisode(episode, uuid));
+    sendResult(res, episodeStorage.updateEpisode(episode));
 };
 export const deleteEpisode: Handler = (req, res) => {
     const { episodeId } = req.body;

--- a/src/server/bin/userMiddleware.ts
+++ b/src/server/bin/userMiddleware.ts
@@ -623,7 +623,7 @@ export const postExternalUser: Handler = (req, res) => {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
     }
-    sendResultCall(res, async () => {
+    sendResult(res, (async () => {
         const listManager = factory(Number(externalUser.type));
         const valid = await listManager.test({ identifier: externalUser.identifier, password: externalUser.pwd });
 
@@ -634,7 +634,7 @@ export const postExternalUser: Handler = (req, res) => {
         externalUser.cookies = listManager.stringifyCookies();
 
         return externalUserStorage.addExternalUser(uuid, externalUser);
-    });
+    })());
 };
 export const deleteExternalUser: Handler = (req, res) => {
     const { externalUuid, uuid } = req.body;

--- a/src/server/bin/userMiddleware.ts
+++ b/src/server/bin/userMiddleware.ts
@@ -151,7 +151,6 @@ export const getAllMedia: Handler = (req, res) => {
     sendResult(res, mediumStorage.getAllMedia());
 };
 
-
 export const putConsumeUnusedMedia: Handler = (req, res) => {
     const { mediumId, tocsMedia } = req.body;
 
@@ -177,6 +176,7 @@ export const getUnusedMedia: Handler = (req, res) => {
 
 export const readNews: Handler = (req, res) => {
     const { uuid, read } = req.body;
+    // TODO: change this validation, should expect a number[]
     if (!read || !isString(read)) {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
@@ -235,14 +235,6 @@ export const processResult: Handler = (req, res) => {
     sendResult(res, storage.processResult(req.body));
 };
 
-export const saveResult: Handler = (req, res) => {
-    if (!req.body) {
-        sendResult(res, Promise.reject(Errors.INVALID_INPUT));
-        return;
-    }
-    sendResult(res, storage.saveResult(req.body));
-};
-
 export const getTunnel: Handler = (req, res) => {
     sendResult(res, Promise.resolve(getTunnelUrls()));
 };
@@ -280,20 +272,12 @@ export const register: Handler = (req, res) => {
 
 export const logout: Handler = (req, res) => {
     const { uuid } = req.body;
+    // TODO: should logout only with valid session
     if (!uuid) {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
     }
     sendResult(res, userStorage.logoutUser(uuid, req.ip));
-};
-
-export const getInvalidated: Handler = (req, res) => {
-    const uuid = extractQueryParam(req, "uuid");
-    if (!uuid) {
-        sendResult(res, Promise.reject(Errors.INVALID_INPUT));
-        return;
-    }
-    sendResult(res, storage.getInvalidatedStream(uuid));
 };
 
 export const addBookmarked: Handler = (req, res) => {
@@ -445,6 +429,7 @@ export const putListMedium: Handler = (req, res) => {
     let { mediumId } = req.body;
 
     if (!Number.isInteger(mediumId)) {
+        // FIXME: should expect number[] not string
         if (isString(mediumId)) {
             mediumId = stringToNumberList(mediumId);
 
@@ -466,6 +451,7 @@ export const deleteListMedium: Handler = (req, res) => {
     const { listId } = req.body;
     let { mediumId } = req.body;
 
+    // FIXME: expect number[] nod string
     // if it is a string, it is likely a list of episodeIds was send
     if (isString(mediumId)) {
         mediumId = stringToNumberList(mediumId);
@@ -583,13 +569,28 @@ export const putEpisode: Handler = (req, res) => {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
     }
-    sendResult(res, episodeStorage.updateEpisode(episode));
+    if (Array.isArray(episode)) {
+        sendResult(res, Promise.all(episode.map(value => episodeStorage.updateEpisode(value))).then(values => {
+            // check if at least one updated
+            return values.findIndex(value => value) >= 0;
+        }));
+    } else {
+        sendResult(res, episodeStorage.updateEpisode(episode));
+    }
 };
 export const deleteEpisode: Handler = (req, res) => {
     const { episodeId } = req.body;
     if (!episodeId || (Array.isArray(episodeId) && !episodeId.length)) {
         sendResult(res, Promise.reject(Errors.INVALID_INPUT));
         return;
+    }
+    if (Array.isArray(episodeId)) {
+        sendResult(res, Promise.all(episodeId.map(value => episodeStorage.updateEpisode(value))).then(values => {
+            // check if at least one updated
+            return values.findIndex(value => value) >= 0;
+        }));
+    } else {
+        sendResult(res, episodeStorage.updateEpisode(episodeId));
     }
     sendResult(res, episodeStorage.deleteEpisode(episodeId));
 };


### PR DESCRIPTION
Expand OpenApi Object Generation.
Add more Transformators for generatic Client Code

- more of an idea
- for Android Java Client
- Browser Javascript/Typescript Client
- Desktop Java Client

The Generator would not only need to create the HTTP Client itself but also have exact Information about the Types for the Request and Response. (at first one can for example assume string only?)